### PR TITLE
Allow a dist.ini file to specify the minimum version of dzil that is needed

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -49,6 +49,18 @@ has chrome => (
   required => 1,
 );
 
+=attr dzil_version
+
+The minimum version of Dist::Zilla that is required. Set this in your C<dist.ini> when
+you know that a minimum version of C<Dist::Zilla> is required
+
+=cut
+
+has dzil_version => (
+  reader  => 'VERSION',
+  trigger => __PACKAGE__->can('VERSION'),
+);
+
 =attr name
 
 The name attribute (which is required) gives the name of the distribution to be


### PR DESCRIPTION
For those cases when a new feature is added to dzil and needed, this allows a dzil_version in dist.ini to specify the minimum needed.
