### PR TITLE
Add :IncModules filefinder and documentation on default finders

### DIFF
--- a/corpus/dist/DZT_Bin/test.pl
+++ b/corpus/dist/DZT_Bin/test.pl
@@ -1,0 +1,3 @@
+#!/usr/bin/perl
+print "Hello World!\n";
+exit;

--- a/corpus/dist/DZT_Inc/Foo.pm
+++ b/corpus/dist/DZT_Inc/Foo.pm
@@ -1,0 +1,8 @@
+#!/usr/bin/perl
+package Foo;
+
+sub baz {
+  'baz';
+}
+
+1;

--- a/corpus/dist/DZT_Inc/Foo/Bar.pm
+++ b/corpus/dist/DZT_Inc/Foo/Bar.pm
@@ -1,0 +1,8 @@
+#!/usr/bin/perl
+package Foo::Bar;
+
+sub baz {
+  'bar';
+}
+
+1;

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -74,13 +74,13 @@ sub _setup_default_plugins {
   unless ($self->plugin_named(':IncModules')) {
     require Dist::Zilla::Plugin::FinderCode;
     my $plugin = Dist::Zilla::Plugin::FinderCode->new({
-      plugin_name => ':InstallModules',
+      plugin_name => ':IncModules',
       zilla       => $self,
       style       => 'grep',
       code        => sub {
         my ($file, $self) = @_;
         local $_ = $file->name;
-        return 1 if m{\Ainc/} and m{\.(pm|pl)$};
+        return 1 if m{\Ainc/} and m{\.pm$};
         return;
       },
     });

--- a/lib/Dist/Zilla/Role/FileFinderUser.pm
+++ b/lib/Dist/Zilla/Role/FileFinderUser.pm
@@ -50,13 +50,17 @@ The default finders are:
 
 =for :list
 * InstallModules
-Searches your lib/ directory for pm/pod files
+Searches your lib/ directory for pm/pod files.
 * IncModules
-Searches your inc/ directory for pm/pl files
+Searches your inc/ directory for pm files.
+* TestFiles
+Searches your t/ directory and lists the files in it.
 * ExecFiles
-Searches your root for any executable files
+Searches your distribution for executable files.
+Hint: Use the L<Dist::Zilla::Plugin::ExecDir> plugin to mark those files as executables.
 * ShareFiles
-Searches your ShareDir directory and lists the files in it
+Searches your ShareDir directory and lists the files in it.
+Hint: Use the L<Dist::Zilla::Plugin::ShareDir> plugin to setup the sharedir.
 
 =cut
 

--- a/t/plugins/filefinders.t
+++ b/t/plugins/filefinders.t
@@ -1,0 +1,103 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+
+use lib 't/lib';
+
+use Test::DZil;
+
+my $tzil = Builder->from_config(
+  { dist_root => 'corpus/dist/DZT' },
+  {
+    add_files => {
+      'source/dist.ini' => simple_ini(
+        [ GatherDir => ],
+        [ GatherDir => MyINC => {
+          root   => '../corpus/dist/DZT_Inc',
+          prefix => 'inc',
+        } ],
+        [ GatherDir => MyBIN => {
+          root   => '../corpus/dist/DZT_Bin',
+          prefix => 'bin',
+        } ],
+        [ ExecDir => ],
+        'Manifest',
+      ),
+    },
+    also_copy => { 'corpus/dist/DZT_Inc' => 'corpus/dist/DZT_Inc',
+                   'corpus/dist/DZT_Bin' => 'corpus/dist/DZT_Bin'
+    },
+  },
+);
+
+$tzil->build;
+
+my @files = map {; $_->name } @{ $tzil->files };
+
+is_filelist(
+  [ @files ],
+  [ qw(
+    dist.ini lib/DZT/Sample.pm t/basic.t
+    MANIFEST
+    inc/Foo.pm inc/Foo/Bar.pm
+    bin/test.pl
+  ) ],
+  "GatherDir gathers all files in the source dir",
+);
+
+my $manifest = $tzil->slurp_file('build/MANIFEST');
+my %in_manifest = map {; chomp; $_ => 1 } grep {length} split /\n/, $manifest;
+
+my $count = grep { $in_manifest{$_} } @files;
+ok($count == @files, "all files found were in manifest");
+ok(keys(%in_manifest) == @files, "all files in manifest were on disk");
+
+# Test our finders
+my $files = $tzil->find_files(':InstallModules');
+is_filelist(
+  [ map {; $_->name } @$files ],
+  [ qw(
+    lib/DZT/Sample.pm
+  ) ],
+  "InstallModules finds all modules",
+);
+
+$files = $tzil->find_files(':IncModules');
+is_filelist(
+  [ map {; $_->name } @$files ],
+  [ qw(
+    inc/Foo.pm inc/Foo/Bar.pm
+  ) ],
+  "IncModules finds all modules",
+);
+
+$files = $tzil->find_files(':TestFiles');
+is_filelist(
+  [ map {; $_->name } @$files ],
+  [ qw(
+    t/basic.t
+  ) ],
+  "TestFiles finds all files",
+);
+
+$files = $tzil->find_files(':ExecFiles');
+is_filelist(
+  [ map {; $_->name } @$files ],
+  [ qw(
+    bin/test.pl
+  ) ],
+  "ExecFiles finds all files",
+);
+
+# XXX I don't use sharedir, how do I configure it? --apocal
+# disabled for now because DZ::Tester doesn't allow sharedir finder to work...
+# Can't locate object method "zilla" via package "Dist::Zilla::Tester::_Builder" at blib/lib/Dist/Zilla/Dist/Builder.pm line 114.
+#$files = $tzil->find_files(':ShareFiles');
+#is_filelist(
+#  [ map {; $_->name } @$files ],
+#  [  ],
+#  "ShareFiles finds all files",
+#);
+
+done_testing;
+


### PR DESCRIPTION
Hello,

  While talking to xdg about my DZP::MinimumPerl plugin, he wanted me to split out the requirements to specific phases of the toolchain. This made me look at the code and realized that there's no finder to search for modules in the inc/ directory.

  Also, there was no documentation on the default finders, so I wrote some in DZ::Role::FileFinderUser, hope you like them :)

Thanks again!
