### PR TITLE
Verbose tests

### DIFF
--- a/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
@@ -28,7 +28,9 @@ sub test {
 
   my $make = $self->make_path;
   $self->build;
-  system($make, 'test') and die "error running $make test\n";
+  system($make, 'test',
+    ( $self->zilla->logger->get_debug ? 'TEST_VERBOSE=1' : () ),
+  ) and die "error running $make test\n";
 
   return;
 }

--- a/lib/Dist/Zilla/Plugin/ModuleBuild.pm
+++ b/lib/Dist/Zilla/Plugin/ModuleBuild.pm
@@ -176,7 +176,9 @@ sub test {
   my ($self, $target) = @_;
 
   $self->build;
-  system($^X, 'Build', 'test') and die "error running $^X Build test\n";
+  system($^X, 'Build', 'test',
+    ( $self->zilla->logger->get_debug ? 'verbose=1' : () ),
+  ) and die "error running $^X Build test\n";
 
   return;
 }


### PR DESCRIPTION
I wanted a way to enable verbose test output without fiddling around with configs/env vars. I think enabling verbose in dzil should enable verbosity in the test output, so it's a nice match.

I hope you'll find it useful too :)
