### PR TITLE
Include file in pkgversion skip

### DIFF
--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -99,7 +99,7 @@ sub munge_perl {
     }
 
     if ($stmt->content =~ /package\s*(?:#.*)?\n\s*\Q$package/) {
-      $self->log([ 'skipping private package %s', $package ]);
+      $self->log([ 'skipping private package %s in %s', $package, $file->name ]);
       next;
     }
 


### PR DESCRIPTION
I was getting really confused because I kept seeing that it was skipping a private Class::MOP package. This turned out to be a use of the CMOP package in Class::MOP::Deprecated.
