### PR TITLE
File munge api

### DIFF
--- a/lib/Dist/Zilla/File/FromCode.pm
+++ b/lib/Dist/Zilla/File/FromCode.pm
@@ -3,7 +3,8 @@ package Dist::Zilla::File::FromCode;
 
 use Moose;
 use Moose::Util::TypeConstraints;
-
+use Params::Util qw( _CODELIKE );
+use Carp qw();
 use namespace::autoclean;
 
 =head1 DESCRIPTION
@@ -103,9 +104,10 @@ sub _set_added_by {
 
 sub munge {
   my ( $self, $munger ) = @_ ;
+  Carp::croak('->munge( munger )  was not passed a coderef' ) unless _CODELIKE($munger);
   my $orig = $self->code;
   $self->code(sub {
-    return $self->$munger( $self->$orig );
+    return $munger->( $self, $self->$orig );
   });
 }
 

--- a/lib/Dist/Zilla/File/FromCode.pm
+++ b/lib/Dist/Zilla/File/FromCode.pm
@@ -101,5 +101,13 @@ sub _set_added_by {
   return $self->_push_added_by(sprintf("%s from coderef added by %s", $self->code_return_type, $value));
 };
 
+sub munge {
+  my ( $self, $munger ) = @_ ;
+  my $orig = $self->code;
+  $self->code(sub {
+    return $self->$munger( $self->$orig );
+  });
+}
+
 __PACKAGE__->meta->make_immutable;
 1;

--- a/lib/Dist/Zilla/Plugin/ExtraTests.pm
+++ b/lib/Dist/Zilla/Plugin/ExtraTests.pm
@@ -52,10 +52,11 @@ sub _rewrite {
   (my $name = $file->name) =~ s{^xt/([^/]+)/}{t/$1-};
 
   $file->name($name);
-
-  my @lines = split /\n/, $file->content;
-  my $after = $lines[0] =~ /\A#!/ ? 1 : 0;
-  splice @lines, $after, 0, qq|
+  $file->munge(sub{
+    my( $self, $content ) = @_ ;
+    my @lines = split /\n/, $content;
+    my $after = $lines[0] =~ /\A#!/ ? 1 : 0;
+    splice @lines, $after, 0, qq|
 BEGIN {
   unless (\$ENV{$env}) {
     require Test::More;
@@ -63,8 +64,8 @@ BEGIN {
   }
 }
 |;
-
-  $file->content(join "\n", @lines, '');
+    return join "\n", @lines, '';
+  });
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Dist/Zilla/Plugin/NextRelease.pm
+++ b/lib/Dist/Zilla/Plugin/NextRelease.pm
@@ -102,17 +102,20 @@ sub munge_files {
   my ($file) = grep { $_->name eq $self->filename } @{ $self->zilla->files };
   return unless $file;
 
-  my $content = $self->fill_in_string(
-    $file->content,
-    {
-      dist    => \($self->zilla),
-      version => \($self->zilla->version),
-      NEXT    => \($self->section_header),
-    },
-  );
+  $file->munge(sub{
+    my( $selffile, $content ) = @_;
+    $content = $self->fill_in_string(
+      $content,
+      {
+        dist    => \($self->zilla),
+        version => \($self->zilla->version),
+        NEXT    => \($self->section_header),
+      },
+    );
 
-  $self->log_debug([ 'updating contents of %s in memory', $file->name ]);
-  $file->content($content);
+    $self->log_debug([ 'updating contents of %s in memory', $file->name ]);
+    return $content;
+  });
 }
 
 # new release is part of distribution history, let's record that.

--- a/lib/Dist/Zilla/Role/File.pm
+++ b/lib/Dist/Zilla/Role/File.pm
@@ -155,4 +155,10 @@ sub _throw {
   );
 }
 
+sub munge {
+  my ( $self, $code ) = @_;
+  my $content = $self->content;
+  $self->content( $self->$code( $content ) );
+}
+
 1;

--- a/lib/Dist/Zilla/Role/File.pm
+++ b/lib/Dist/Zilla/Role/File.pm
@@ -5,7 +5,8 @@ use Moose::Role;
 
 use Moose::Util::TypeConstraints;
 use Try::Tiny;
-
+use Params::Util qw( _CODELIKE );
+use Carp qw();
 use namespace::autoclean;
 
 with 'Dist::Zilla::Role::StubBuild';
@@ -157,8 +158,9 @@ sub _throw {
 
 sub munge {
   my ( $self, $code ) = @_;
+  Carp::croak("->munge( code ) was not passed a coderef") unless _CODELIKE($code);
   my $content = $self->content;
-  $self->content( $self->$code( $content ) );
+  $self->content( $code->($self,$content ) );
 }
 
 1;


### PR DESCRIPTION
This is mostly a request for a review of ideas and implementation. 

If you like the concept , or think it needs work, get back to me =). 

the idea is to unify the way people munge files, which currently has to be done differently depending on whether its a file from code, or a string file.

This doesn't appear to be a problem much at the moment, but if you try making a test or anything that gets moved/munged a File::FromCode, it will explode in a ball of fire when the munger tries to do 

$file->content( $foo ) and the FromCode file is immutable in that context.

The Munge API simplifies this by making consumers interact with the content via a callback fashion, forcing a sub-ref, so the underlying infrastructure can do the right thing, and either modify the content _now_, or use coderef chaining so the files content is aggregated when its needed.

```
$file->munge(sub{ 
    my( $fileself, $content ) = @_; 
    return munged($content);
});
```

On normal files, the code runs immediately, on FromCode files, it chains it so its more like this:

```
my $orig = $file->{coderef}; 
$file->{coderef} = sub { 
     my $content = $orig->(); 
     return munge( $content );
};
```
