### PR TITLE
Add --clean option to dzil release

### DIFF
--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -8,12 +8,13 @@ use Dist::Zilla::App -command;
 
   dzil release
 
-  dzil release --trial
+  dzil release [ --trial ] [ --clean ]
 
 This command is a very, very thin wrapper around the
 C<L<release|Dist::Zilla/release>> method on the Dist::Zilla object.  It will
 build, archive, and release your distribution using your Releaser plugins.  The
-only option, C<--trial>, will cause it to build a trial build.
+only option, C<--trial>, will cause it to build a trial build. C<--clean> will
+run C<dzil clean> after the release.
 
 =cut
 
@@ -21,6 +22,7 @@ sub abstract { 'release your dist' }
 
 sub opt_spec {
   [ 'trial' => 'build a trial release that PAUSE will not index' ],
+  [ 'clean' => 'clean up after release' ]
 }
 
 sub execute {
@@ -31,6 +33,8 @@ sub execute {
   $zilla->is_trial(1) if $opt->trial;
 
   $self->zilla->release;
+
+  $self->zilla->clean if $opt->clean;
 }
 
 1;


### PR DESCRIPTION
I always run 'dzil clean' immediately after 'dzil release', so I added an option to 'release' to do just that.
