### PR TITLE
Fix for RT #64896: skip undef plugins in PluginBundle::Easy

### DIFF
--- a/lib/Dist/Zilla/Role/PluginBundle/Easy.pm
+++ b/lib/Dist/Zilla/Role/PluginBundle/Easy.pm
@@ -124,6 +124,7 @@ sub add_plugins {
   my $plugins = $self->plugins;
 
   foreach my $this_spec (@plugin_specs) {
+    next unless defined $this_spec; # skip undef - RT #64896
     my $moniker;
     my $name;
     my $payload;


### PR DESCRIPTION
A naive pluginbundle author might do:
    $self->add_plugins(
        'Plugin',
        'AnotherPlugin',
        ( $self->switch ? 'Switch' : 'FakeSwitch' ); # Does what you expect
        ( $self->stop   ? undef    : 'Continue'   ); # Dies a horrible death
    );

Ignoring undefined plugins resolves this issue.

Fixes RT #64896
