### PR TITLE
add a PreviousVersionProvider role

### DIFF
--- a/lib/Dist/Zilla/Role/PreviousVersionProvider.pm
+++ b/lib/Dist/Zilla/Role/PreviousVersionProvider.pm
@@ -1,0 +1,19 @@
+package Dist::Zilla::Role::PreviousVersionProvider;
+# ABSTRACT: something that provides the dist's previous version number
+use Moose::Role;
+with 'Dist::Zilla::Role::Plugin';
+
+=head1 DESCRIPTION
+
+Plugins implementing this role must provide a C<previous_version> 
+method that might be called when another (or the same) plugin implementing
+the C<VersionProvider> role will set the dist's version. 
+
+If no previous version exists, the plugin is expected to return C<undef>.
+
+=cut
+
+requires 'previous_version';
+
+no Moose::Role;
+1;


### PR DESCRIPTION
Right now, plugins implementing the VersionProvider role
are doing up to two different tasks: retrieving the previous
version number, and incrementing it according to a given scheme.
The goal of the PreviousVersionProvider role is to split those
tasks between the two roles.

Of course, I'm not submitting the patch without having some secret
agenda: I seek this new role as a way to cleanly split the semantic
versioning scheme and the Git component that I'm using in
http://babyl.dyndns.org/techblog/entry/dist-zilla-semanticversion