### PR TITLE
Prune distmeta.t when META.yml doesn't exist

### DIFF
--- a/lib/Dist/Zilla/Plugin/MetaTests.pm
+++ b/lib/Dist/Zilla/Plugin/MetaTests.pm
@@ -1,16 +1,38 @@
 package Dist::Zilla::Plugin::MetaTests;
 # ABSTRACT: common extra tests for META.yml
 use Moose;
+use Moose::Autobox;
 extends 'Dist::Zilla::Plugin::InlineFiles';
+with 'Dist::Zilla::Role::FilePruner';
 
 =head1 DESCRIPTION
 
 This is an extension of L<Dist::Zilla::Plugin::InlineFiles>, providing the
-following files:
+following file if F<META.yml> is in your dist:
 
   xt/release/meta-yaml.t - a standard Test::CPAN::Meta test
 
 =cut
+
+sub prune_files {
+    my $self = shift;
+
+    # Bail if we find META.yml
+    my $METAyml = 'META.yml';
+    foreach my $file ($self->zilla->files->flatten) {
+        return if $file->name eq $METAyml;
+    }
+
+    # If META.yml wasn't found, then prune out the test
+    my $test_filename = 'xt/release/distmeta.t';
+    foreach my $file ($self->zilla->files->flatten) {
+        next unless $file->name eq $test_filename;
+
+        $self->zilla->prune_file($file);
+        $self->log_debug([ '%s not found; pruning %s', $METAyml, $file->name ]);
+    }
+    return;
+}
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/t/plugins/misctests.t
+++ b/t/plugins/misctests.t
@@ -1,32 +1,59 @@
 use strict;
 use warnings;
-use Test::More 0.88;
+use Test::More 0.88 tests => 2;
 
 use lib 't/lib';
 
 use autodie;
 use Test::DZil;
+use Moose::Autobox;
 
-my $tzil = Builder->from_config(
-  { dist_root => 'corpus/dist/DZT' },
-  {
-    add_files => {
-      'source/dist.ini' => simple_ini(
-        qw(GatherDir MetaTests PodSyntaxTests PodCoverageTests)
-      ),
+subtest 'No META.yml' => sub {
+  plan tests => 3;
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          qw(GatherDir MetaTests PodSyntaxTests PodCoverageTests)
+        ),
+      },
     },
-  },
-);
+  );
 
-$tzil->build;
+  $tzil->build;
 
-my $meta_test = $tzil->slurp_file('build/xt/release/distmeta.t');
-like($meta_test, qr{meta_yaml_ok}, "we have a distmeta file that tests it");
+  my $has_distmeta_test = grep( $_->name eq 'xt/release/distmeta.t', $tzil->files->flatten);
+  ok(!$has_distmeta_test, 'distmeta.t was pruned out');
 
-my $pod_test = $tzil->slurp_file('build/xt/release/pod-syntax.t');
-like($pod_test, qr{all_pod_files_ok}, "we have a pod-syntax test");
+  my $pod_test = $tzil->slurp_file('build/xt/release/pod-syntax.t');
+  like($pod_test, qr{all_pod_files_ok}, "we have a pod-syntax test");
 
-my $pod_c_test = $tzil->slurp_file('build/xt/release/pod-coverage.t');
-like($pod_c_test, qr{all_pod_coverage_ok}, "we have a pod-coverage test");
+  my $pod_c_test = $tzil->slurp_file('build/xt/release/pod-coverage.t');
+  like($pod_c_test, qr{all_pod_coverage_ok}, "we have a pod-coverage test");
+};
 
-done_testing;
+subtest 'META.yml' => sub {
+  plan tests => 3;
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          qw(MetaYAML GatherDir MetaTests PodSyntaxTests PodCoverageTests)
+        ),
+      },
+    },
+  );
+
+  $tzil->build;
+
+  my $meta_test = $tzil->slurp_file('build/xt/release/distmeta.t');
+  like($meta_test, qr{meta_yaml_ok}, "we have a distmeta file that tests it");
+
+  my $pod_test = $tzil->slurp_file('build/xt/release/pod-syntax.t');
+  like($pod_test, qr{all_pod_files_ok}, "we have a pod-syntax test");
+
+  my $pod_c_test = $tzil->slurp_file('build/xt/release/pod-coverage.t');
+  like($pod_c_test, qr{all_pod_coverage_ok}, "we have a pod-coverage test");
+};


### PR DESCRIPTION
This prunes the test file when `META.yml` doesn't exist in the dist. This makes it easier to include in pluginbundles, where you don't necessarily know whether the file will be there. A test to make sure the file is indeed pruned when appropriate has been added
