### PR TITLE
Silence a spurious undefined warning

### DIFF
--- a/lib/Test/DZil.pm
+++ b/lib/Test/DZil.pm
@@ -131,7 +131,7 @@ sub _build_ini_builder {
                    ? @{ $payload->{ $key } }
                    : $payload->{ $key };
 
-        $config .= "$key = $_\n" for @values;
+        $config .= "$key = $_\n" for grep {defined} @values;
       }
 
       $config .= "\n";


### PR DESCRIPTION
Another spot to check `defined` before use in order to silence an undefined warning.
