### PR TITLE
First sketch of "keywords" core attribute

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,6 +2,7 @@ name    = Dist-Zilla
 author  = Ricardo SIGNES <rjbs@cpan.org>
 license = Perl_5
 copyright_holder = Ricardo SIGNES
+keywords = cpan author dist
 
 [@RJBS]
 

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -367,6 +367,34 @@ has authors => (
   },
 );
 
+=attr keywords
+
+This is an arrayref of keywords (tags) that describe the distribution, like this:
+
+  [
+    'app',
+    'cpan',
+    'admin',
+  ]
+
+=cut
+
+has keywords => (
+  is   => 'ro',
+  isa  => ArrayRef[Str],
+  init_arg => undef,
+  lazy => 1,
+  builder   => '_build_keywords',
+);
+
+sub _build_keywords {
+  my ($self) = @_;
+
+  # TODO: Somehow get $keywords from dist.ini and return [split(/\s+/, $keywords)] here.
+  return [];
+}
+
+
 =attr files
 
 This is an arrayref of objects implementing L<Dist::Zilla::Role::File> that
@@ -471,6 +499,7 @@ sub _build_distmeta {
     abstract => $self->abstract,
     author   => $self->authors,
     license  => $self->license->meta2_name,
+    keywords => $self->keywords,
 
     # XXX: what about unstable?
     release_status => ($self->is_trial or $self->version =~ /_/)

--- a/lib/Dist/Zilla/Plugin/DistINI.pm
+++ b/lib/Dist/Zilla/Plugin/DistINI.pm
@@ -76,7 +76,7 @@ sub gather_files {
   });
 
   my $code = sub {
-    my @core_attrs = qw(name authors copyright_holder);
+    my @core_attrs = qw(name authors copyright_holder keywords);
 
     my $license = ref $zilla->license;
     if ($license =~ /^Software::License::(.+)$/) {
@@ -91,6 +91,7 @@ sub gather_files {
     $content .= sprintf "license = %s\n", $license;
     $content .= sprintf "copyright_holder = %s\n", $zilla->copyright_holder;
     $content .= sprintf "copyright_year   = %s\n", (localtime)[5] + 1900;
+    $content .= sprintf "keywords = %s\n", join(' ', @{ $zilla->keywords });
     $content .= "\n";
 
     $content .= $postlude;

--- a/lib/Test/DZil.pm
+++ b/lib/Test/DZil.pm
@@ -202,6 +202,7 @@ The starter config may change slightly over time, but is something like this:
     author   => 'E. Xavier Ample <example@example.org>',
     license  => 'Perl_5',
     copyright_holder => 'E. Xavier Ample',
+    keywords => 'app cpan admin',
   }
 
 =cut
@@ -214,6 +215,7 @@ sub _simple_ini {
     author   => 'E. Xavier Ample <example@example.org>',
     license  => 'Perl_5',
     copyright_holder => 'E. Xavier Ample',
+    keywords => 'app cpan admin',
   });
 }
 

--- a/t/plugins/distmeta.t
+++ b/t/plugins/distmeta.t
@@ -135,6 +135,7 @@ use YAML::Tiny;
         license  => 'http://b.sd/license',
       },
       version   => '0.001',
+      keywords  => [qw[ app cpan admin ]],
     );
 
     for my $key (sort keys %want) {


### PR DESCRIPTION
Hi! This pull request implements the "keywords" array as defined in META spec v1.4:
    http://module-build.sourceforge.net/META-spec-v1.4.html#keywords

As keywords cannot contain whitespace themselves, I wonder if we can have just one whitespace-separated line in dist.ini, e.g.:

```
name    = Dist-Zilla
license = Perl_5
keywords = cpan author dist
```

Currently the t/plugins/distmeta.t test is failing, as I have not grokked how to read it from dist.ini yet... Guidance appreciated! :-)
