### PR TITLE
Fix failing test in 4.200011

### DIFF
--- a/t/tester.t
+++ b/t/tester.t
@@ -25,7 +25,7 @@ my $basename = join(q{},
 my $tarball = "$basename.tar.gz";
 
 $tarball = $tzil->built_in->parent->subdir('source')->file($tarball);
-$tarball = Archive::Tar->new($tarball);
+$tarball = Archive::Tar->new($tarball->stringify);
 
 my $makefile_pl = File::Spec->catfile($basename, 'Makefile.PL');
 


### PR DESCRIPTION
t/tester.t in 4.200011 fails on my machine with the following error:

Can't locate object method "read" via package "Path::Class::File" at /usr/share/perl/5.12/Archive/Tar.pm line 317.

Upgrading Archive::Tar from version 1.54 (from Debian testing's perl-modules package) to 1.76 does solve the problem, but I have not examined the exact differences between these versions.

This commit forces stringification of the Path::Class::File object in t/tester.t, and seems to maintain compatibility with the older Archive::Tar. Tested against both versions by patching Dist-Zilla-4.200011.tar.gz and doing `cpanm .`. :-)
