### PR TITLE
allow tester.t to pass on Win32

### DIFF
--- a/t/tester.t
+++ b/t/tester.t
@@ -27,7 +27,7 @@ my $tarball = "$basename.tar.gz";
 $tarball = $tzil->built_in->parent->subdir('source')->file($tarball);
 $tarball = Archive::Tar->new($tarball->stringify);
 
-my $makefile_pl = File::Spec->catfile($basename, 'Makefile.PL');
+my $makefile_pl = File::Spec::Unix->catfile($basename, 'Makefile.PL');
 
 ok(
   $tarball->contains_file( $makefile_pl ),


### PR DESCRIPTION
The paths of the files in Archive::Tar are unix format and do not change to the native format when interrogated, as such they need to be interrogated with unix-style paths.
