### PR TITLE
Adding MooseX::SetOnce requirement to dist.ini.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -21,6 +21,7 @@ x_mailing_list  = http://www.listbox.com/subscribe/?list_id=139292
 
 [Prereqs / TestRequires]
 Test::More = 0.90
+MooseX::SetOnce = 0
 
 [Prereqs / RuntimeRecommends]
 Term::ReadLine::Gnu = 0


### PR DESCRIPTION
The tests would not pass for me until I installed MooseX::SetOnce. I was only able to figure this out because of: http://www.perlmonks.org/?node_id=903657

I have also made a RT ticket for this:
https://rt.cpan.org/Ticket/Display.html?id=72047&results=cc860d6b5dbfd3bde95576b901d954df
