### PR TITLE
Test more abstract_from_file

### DIFF
--- a/corpus/dist/DZ2/lib/DZ1.pm
+++ b/corpus/dist/DZ2/lib/DZ1.pm
@@ -1,10 +1,16 @@
 use strict;
 use warnings;
 package DZ1;
-# ABSTRACT: this is a sample package for testing Dist::Zilla;
 
 sub main {
   return 1;
 }
 
 1;
+__END__
+
+=head1 NAME
+
+DZ1 - this is a sample package for testing Dist::Zilla;
+
+=cut


### PR DESCRIPTION
Modify corpus/dist/DZ2/DZ1.pm to set the abstract from POD instead of an
"# ABSTRACT:" line. This improves a bit the code coverage of DZ::Util.
