### PR TITLE
Add diag_log method and auto_diag option

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+          Dist::Zilla::Tester objects now have a diag_log method to
+          dump the log messages to Test::Builder's diag function.
+          Adding "auto_log => 1" to the tester parameters does this
+          automatically during destruction if any tests failed since
+          the object was constructed (Thanks, Christopher J. Madsen!)
 
 4.300009  2012-02-21 19:38:29 America/New_York
           PruneCruft also excludes the _Inline/ directory and MYMETA.json

--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -51,14 +51,14 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
     scalar grep { !$_ } Test::Builder->new->summary;
   } # end _current_failure_count
 
-  sub DEMOLISH {
+  before 'DESTROY' => sub {
     my ($self) = @_;
 
     my $orig_failures = $self->_orig_failure_count;
 
     $self->diag_log if defined $orig_failures
         and $self->_current_failure_count > $orig_failures;
-  }
+  };
 
   sub clear_log_events {
     my ($self) = @_;

--- a/t/plugins/distmeta.t
+++ b/t/plugins/distmeta.t
@@ -14,6 +14,7 @@ use YAML::Tiny;
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },
     {
+      auto_diag => 1,
       add_files => {
         'source/dist.ini' => simple_ini(
           'GatherDir',
@@ -85,6 +86,7 @@ use YAML::Tiny;
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },
     {
+      auto_diag => 1,
       add_files => {
         'source/dist.ini' => simple_ini(
           'GatherDir',

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -68,112 +68,117 @@ my $script_pkg = '
 package DZT::Script;
 ';
 
-my $tzil = Builder->from_config(
-  { dist_root => 'corpus/dist/DZT' },
-  {
-    add_files => {
-      'source/lib/DZT/TP1.pm'    => $two_packages,
-      'source/lib/DZT/WVer.pm'   => $with_version,
-      'source/lib/DZT/WVerTwoLines.pm' => $with_version_two_lines,
-      'source/lib/DZT/R1.pm'     => $repeated_packages,
-      'source/lib/DZT/Monkey.pm' => $monkey_patched,
-      'source/lib/DZT/HideMe.pm' => $hide_me_comment,
-      'source/bin/script_pkg.pl' => $script_pkg,
-      'source/bin/script_ver.pl' => $script_pkg . "our \$VERSION = 1.234;\n",
-      'source/bin/script.pl'     => $script,
-      'source/dist.ini' => simple_ini('GatherDir', 'PkgVersion', 'ExecDir'),
+{
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      auto_diag => 1,
+      add_files => {
+        'source/lib/DZT/TP1.pm'    => $two_packages,
+        'source/lib/DZT/WVer.pm'   => $with_version,
+        'source/lib/DZT/WVerTwoLines.pm' => $with_version_two_lines,
+        'source/lib/DZT/R1.pm'     => $repeated_packages,
+        'source/lib/DZT/Monkey.pm' => $monkey_patched,
+        'source/lib/DZT/HideMe.pm' => $hide_me_comment,
+        'source/bin/script_pkg.pl' => $script_pkg,
+        'source/bin/script_ver.pl' => $script_pkg . "our \$VERSION = 1.234;\n",
+        'source/bin/script.pl'     => $script,
+        'source/dist.ini' => simple_ini('GatherDir', 'PkgVersion', 'ExecDir'),
+      },
     },
-  },
-);
-
-$tzil->build;
-
-my $dzt_sample = $tzil->slurp_file('build/lib/DZT/Sample.pm');
-like(
-  $dzt_sample,
-  qr{^\s*\$\QDZT::Sample::VERSION = '0.001';\E\s*$}m,
-  "added version to DZT::Sample",
-);
-
-my $dzt_tp1 = $tzil->slurp_file('build/lib/DZT/TP1.pm');
-like(
-  $dzt_tp1,
-  qr{^\s*\$\QDZT::TP1::VERSION = '0.001';\E\s*$}m,
-  "added version to DZT::TP1",
-);
-
-like(
-  $dzt_tp1,
-  qr{^\s*\$\QDZT::TP2::VERSION = '0.001';\E\s*$}m,
-  "added version to DZT::TP2",
-);
-
-my $dzt_wver = $tzil->slurp_file('build/lib/DZT/WVer.pm');
-unlike(
-  $dzt_wver,
-  qr{^\s*\$\QDZT::WVer::VERSION = '0.001';\E\s*$}m,
-  "*not* added to DZT::WVer; we have one already",
-);
-
-my $dzt_wver_two_lines = $tzil->slurp_file('build/lib/DZT/WVerTwoLines.pm');
-unlike(
-  $dzt_wver,
-  qr{^\s*\$\QDZT::WVer::VERSION = '0.001';\E\s*$}m,
-  "*not* added to DZT::WVerTwoLines; we have one already",
-);
-
-my $dzt_script_pkg = $tzil->slurp_file('build/bin/script_pkg.pl');
-like(
-  $dzt_script_pkg,
-  qr{^\s*\$\QDZT::Script::VERSION = '0.001';\E\s*$}m,
-  "added version to DZT::Script",
-);
-
-TODO: {
-  local $TODO = 'only scanning for packages right now';
-  my $dzt_script = $tzil->slurp_file('build/bin/script.pl');
-  like(
-    $dzt_script,
-    qr{^\s*\$\QDZT::Script::VERSION = '0.001';\E\s*$}m,
-    "added version to plain script",
   );
-};
 
-my $script_wver = $tzil->slurp_file('build/bin/script_ver.pl');
-unlike(
-  $script_wver,
-  qr{^\s*\$\QDZT::WVer::VERSION = '0.001';\E\s*$}m,
-  "*not* added to versioned DZT::Script; we have one already",
-);
+  $tzil->plugin_named('PkgVersion')->logger->set_debug(1);
 
-ok(
-  grep({ m(skipping lib/DZT/WVer\.pm: assigns to \$VERSION) }
-    @{ $tzil->log_messages }),
-  "we report the reason for no updateing WVer",
-);
+  $tzil->build;
 
-my $dzt_r1 = $tzil->slurp_file('build/lib/DZT/R1.pm');
-my @matches = grep { /R1::VER/ } split /\n/, $dzt_r1;
-is(@matches, 1, "we add at most 1 VERSION per package");
+  my $dzt_sample = $tzil->slurp_file('build/lib/DZT/Sample.pm');
+  like(
+    $dzt_sample,
+    qr{^\s*\$\QDZT::Sample::VERSION = '0.001';\E\s*$}m,
+    "added version to DZT::Sample",
+  );
 
-my $dzt_monkey = $tzil->slurp_file('build/lib/DZT/Monkey.pm');
-unlike(
-  $dzt_monkey,
-  qr{\$DZT::TP2::VERSION},
-  "no version for DZT::TP2 when it looks like a monkey patch"
-);
+  my $dzt_tp1 = $tzil->slurp_file('build/lib/DZT/TP1.pm');
+  like(
+    $dzt_tp1,
+    qr{^\s*\$\QDZT::TP1::VERSION = '0.001';\E\s*$}m,
+    "added version to DZT::TP1",
+  );
 
-ok(
-  grep({ m(skipping .+ DZT::TP2) } @{ $tzil->log_messages }),
-  "we report the reason for not updating Monkey",
-);
+  like(
+    $dzt_tp1,
+    qr{^\s*\$\QDZT::TP2::VERSION = '0.001';\E\s*$}m,
+    "added version to DZT::TP2",
+  );
 
-my $dzt_hideme = $tzil->slurp_file('build/lib/DZT/HideMe.pm');
-unlike(
-  $dzt_hideme,
-  qr{\$DZT::TP2::VERSION},
-  "no version for DZT::TP2 when it was hidden with a comment"
-);
+  my $dzt_wver = $tzil->slurp_file('build/lib/DZT/WVer.pm');
+  unlike(
+    $dzt_wver,
+    qr{^\s*\$\QDZT::WVer::VERSION = '0.001';\E\s*$}m,
+    "*not* added to DZT::WVer; we have one already",
+  );
+
+  my $dzt_wver_two_lines = $tzil->slurp_file('build/lib/DZT/WVerTwoLines.pm');
+  unlike(
+    $dzt_wver,
+    qr{^\s*\$\QDZT::WVer::VERSION = '0.001';\E\s*$}m,
+    "*not* added to DZT::WVerTwoLines; we have one already",
+  );
+
+  my $dzt_script_pkg = $tzil->slurp_file('build/bin/script_pkg.pl');
+  like(
+    $dzt_script_pkg,
+    qr{^\s*\$\QDZT::Script::VERSION = '0.001';\E\s*$}m,
+    "added version to DZT::Script",
+  );
+
+  TODO: {
+    local $TODO = 'only scanning for packages right now';
+    my $dzt_script = $tzil->slurp_file('build/bin/script.pl');
+    like(
+      $dzt_script,
+      qr{^\s*\$\QDZT::Script::VERSION = '0.001';\E\s*$}m,
+      "added version to plain script",
+    );
+  };
+
+  my $script_wver = $tzil->slurp_file('build/bin/script_ver.pl');
+  unlike(
+    $script_wver,
+    qr{^\s*\$\QDZT::WVer::VERSION = '0.001';\E\s*$}m,
+    "*not* added to versioned DZT::Script; we have one already",
+  );
+
+  ok(
+    grep({ m(skipping lib/DZT/WVer\.pm: assigns to \$VERSION) }
+      @{ $tzil->log_messages }),
+    "we report the reason for no updateing WVer",
+  );
+
+  my $dzt_r1 = $tzil->slurp_file('build/lib/DZT/R1.pm');
+  my @matches = grep { /R1::VER/ } split /\n/, $dzt_r1;
+  is(@matches, 1, "we add at most 1 VERSION per package");
+
+  my $dzt_monkey = $tzil->slurp_file('build/lib/DZT/Monkey.pm');
+  unlike(
+    $dzt_monkey,
+    qr{\$DZT::TP2::VERSION},
+    "no version for DZT::TP2 when it looks like a monkey patch"
+  );
+
+  ok(
+    grep({ m(skipping .+ DZT::TP2) } @{ $tzil->log_messages }),
+    "we report the reason for not updating Monkey",
+  );
+
+  my $dzt_hideme = $tzil->slurp_file('build/lib/DZT/HideMe.pm');
+  unlike(
+    $dzt_hideme,
+    qr{\$DZT::TP2::VERSION},
+    "no version for DZT::TP2 when it was hidden with a comment"
+  );
+}
 
 {
   local $ENV{TRIAL} = 1;
@@ -181,11 +186,14 @@ unlike(
   my $tzil_trial = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },
     {
+      auto_diag => 1,
       add_files => {
         'source/dist.ini' => simple_ini('GatherDir', 'PkgVersion', 'ExecDir'),
       },
     },
   );
+
+  $tzil_trial->plugin_named('PkgVersion')->logger->set_debug(1);
 
   $tzil_trial->build;
 
@@ -198,4 +206,3 @@ unlike(
 }
 
 done_testing;
-


### PR DESCRIPTION
I was thinking that something like diag_log ought to be in core.  I came up with a nicer way of doing it.  You just add `auto_diag => 1` to the tester parameters when creating your `$tzil` object.  That causes it to record the current number of failed tests.  When `$tzil` is destroyed, if there have been additional test failures, it writes out the log messages.

`$tzil->diag_log` passes the log entries to Test::Builder's diag()

`auto_diag => 1` does that automatically if any tests fail between construction and destruction
