### PR TITLE
Add FileFinder::Filter

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+          a new FileFinder plugin has been added, FileFinder::Filter
+          (Thanks, Christopher J. Madsen!)
 
 4.300003  2011-10-31 23:58:19 America/New_York
           If no credentials are found on disk, UploadToCPAN will now prompt for

--- a/lib/Dist/Zilla/Plugin/FileFinder/Filter.pm
+++ b/lib/Dist/Zilla/Plugin/FileFinder/Filter.pm
@@ -1,0 +1,93 @@
+package Dist::Zilla::Plugin::FileFinder::Filter;
+use Moose;
+with(
+  'Dist::Zilla::Role::FileFinder',
+  'Dist::Zilla::Role::FileFinderUser' => {
+    default_finders => [],
+  },
+);
+# ABSTRACT: filter matches from other FileFinders
+
+use namespace::autoclean;
+
+=head1 SYNOPSIS
+
+In your F<dist.ini>:
+
+  [FileFinder::Filter / MyFiles]
+  finder = :InstallModules ; find files from :InstallModules
+  finder = :ExecFiles      ; or :ExecFiles
+  skip  = ignore           ; that don't have "ignore" in the path
+
+=head1 CREDITS
+
+This plugin was originally contributed by Christopher J. Madsen.
+
+=cut
+
+use Moose::Util::TypeConstraints;
+use MooseX::Types::Moose qw(ArrayRef RegexpRef Str);
+
+{
+  my $type = subtype as ArrayRef[RegexpRef];
+  coerce $type, from ArrayRef[Str], via { [map { qr/$_/ } @$_] };
+
+=attr finder
+
+A FileFinder to supply the initial list of files.
+May occur multiple times.
+
+=attr skip
+
+The pathname must I<not> match any of these regular expressions.
+May occur multiple times.
+
+=cut
+
+  has skips => (
+    is      => 'ro',
+    isa     => $type,
+    coerce  => 1,
+    default => sub { [] },
+  );
+}
+
+sub mvp_aliases { +{ qw(
+  skip     skips
+) } }
+
+sub mvp_multivalue_args { qw(skips) }
+
+sub find_files {
+  my $self = shift;
+
+  my $files = $self->found_files;
+
+  foreach my $re (@{ $self->skips }) {
+    @$files = grep { $_->name !~ $re } @$files;
+  }
+
+  $self->log_debug("No files found") unless @$files;
+  $self->log_debug("Found " . $_->name) for @$files;
+
+  $files;
+}
+
+__PACKAGE__->meta->make_immutable;
+1;
+
+__END__
+
+=head1 DESCRIPTION
+
+FileFinder::Filter is a L<FileFinder|Dist::Zilla::Role::FileFinder> that
+selects files by filtering the selections of other FileFinders.
+
+You specify one or more FileFinders to generate the initial list of
+files.  Any file whose pathname matches any of the C<skip> regexs is
+removed from that list.
+
+=for Pod::Coverage
+mvp_aliases
+mvp_multivalue_args
+find_files

--- a/t/plugins/ffbyname.t
+++ b/t/plugins/ffbyname.t
@@ -1,5 +1,5 @@
 #!perl
-# Test the FileFinder::ByName plugin
+# Test the FileFinder::ByName and FileFinder::Filter plugins
 use strict;
 use warnings;
 
@@ -77,7 +77,8 @@ sub make_tzil {
 }
 
 #---------------------------------------------------------------------
-make_tzil([ 'FileFinder::ByName' => {qw(dir corpus  skip archives)}]);
+make_tzil([ 'FileFinder::ByName' => {qw(dir corpus  skip archives)}],
+          [ 'FileFinder::Filter' => {qw(finder FileFinder::ByName  skip DZT)}]);
 
 is_found('FileFinder::ByName' => [qw(
   corpus/DZT/README
@@ -86,6 +87,11 @@ is_found('FileFinder::ByName' => [qw(
   corpus/README
   corpus/gitvercheck.git
 )], 'dir corpus skip archives');
+
+is_found('FileFinder::Filter' => [qw(
+  corpus/README
+  corpus/gitvercheck.git
+)], 'filter DZT');
 
 #---------------------------------------------------------------------
 make_tzil(
@@ -96,6 +102,10 @@ make_tzil(
                                           dir  => [qw(bin lib)],
                                           match => '\.pm$',
                                           skip  => '(?i)version' }],
+  [ 'FileFinder::Filter' => Everything =>
+    { finder => [qw(InBin AllPerl Plugins Synopsis)] }],
+  [ 'FileFinder::Filter' => NoPluginM =>
+    { finder => 'AllPerl', skip => 'Plugin/M' }],
 );
 
 is_found(InBin => [qw(
@@ -135,6 +145,32 @@ is_found(Synopsis => [qw(
   lib/Dist/Zilla/Plugin/Metadata.pm
   lib/Dist/Zilla/Plugin/ModuleBuild/Custom.pm
   lib/Dist/Zilla/Plugin/TemplateCJM.pm
+  lib/Dist/Zilla/Role/ModuleInfo.pm
+)]);
+
+is_found(Everything => [qw(
+  bin/foo.pl
+  bin/.hidden/foo.pl
+  corpus/DZT/lib/DZT/Sample.pm
+  lib/Dist/Zilla/Plugin/ArchiveRelease.pm
+  lib/Dist/Zilla/Plugin/FindFiles.pm
+  lib/Dist/Zilla/Plugin/GitVersionCheckCJM.pm
+  lib/Dist/Zilla/Plugin/Metadata.pm
+  lib/Dist/Zilla/Plugin/ModuleBuild/Custom.pm
+  lib/Dist/Zilla/Plugin/TemplateCJM.pm
+  lib/Dist/Zilla/Plugin/VersionFromModule.pm
+  lib/Dist/Zilla/Role/ModuleInfo.pm
+)]);
+
+is_found(NoPluginM => [qw(
+  bin/foo.pl
+  bin/.hidden/foo.pl
+  corpus/DZT/lib/DZT/Sample.pm
+  lib/Dist/Zilla/Plugin/ArchiveRelease.pm
+  lib/Dist/Zilla/Plugin/FindFiles.pm
+  lib/Dist/Zilla/Plugin/GitVersionCheckCJM.pm
+  lib/Dist/Zilla/Plugin/TemplateCJM.pm
+  lib/Dist/Zilla/Plugin/VersionFromModule.pm
   lib/Dist/Zilla/Role/ModuleInfo.pm
 )]);
 


### PR DESCRIPTION
Add its tests to `ffbyname.t`, because it needs results from another finder, and failures in that finder will cascade anyway
