### PR TITLE
Don't echo the password at the prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 Dist-Zilla-*
 .build
 tmp
+*.patch
 
 # avoid temp and backup files
 *~

--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Revision history for {{$dist->name}}
           a new FileFinder plugin has been added, FileFinder::Filter
           (Thanks, Christopher J. Madsen!)
 
+          Your PAUSE password will now no be echoed if entered at the
+          prompt (Mike Doherty)
+
 4.300003  2011-10-31 23:58:19 America/New_York
           If no credentials are found on disk, UploadToCPAN will now prompt for
           credentials during the BeforeRelease phase, not during release

--- a/lib/Dist/Zilla/Chrome/Term.pm
+++ b/lib/Dist/Zilla/Chrome/Term.pm
@@ -56,11 +56,21 @@ sub prompt_str {
   my $default = $arg->{default};
   my $check   = $arg->{check};
 
+  if ($arg->{noecho}) {
+    require Term::ReadKey;
+    Term::ReadKey::ReadMode('noecho');
+  }
   my $input_bytes = $self->term_ui->get_reply(
     prompt => $prompt,
     allow  => $check || sub { defined $_[0] and length $_[0] },
     (defined $default ? (default => $default) : ()),
   );
+  if ($arg->{noecho}) {
+    Term::ReadKey::ReadMode('normal');
+    # The \n ending user input disappears under noecho; this ensures
+    # the next output ends up on the next line.
+    print "\n";
+  }
 
   my $input = decode_utf8( $input_bytes );
   chomp $input;

--- a/lib/Dist/Zilla/Plugin/UploadToCPAN.pm
+++ b/lib/Dist/Zilla/Plugin/UploadToCPAN.pm
@@ -111,7 +111,7 @@ has password => (
     my ($self) = @_;
     return $self->_credential('password')
         || $self->pause_cfg->{password}
-        || $self->zilla->chrome->prompt_str("PAUSE password (will echo): ");
+        || $self->zilla->chrome->prompt_str('PAUSE password: ', { noecho => 1 });
   },
 );
 

--- a/t/plugins/uploadtocpan.t
+++ b/t/plugins/uploadtocpan.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More 0.88;
+use Test::More 0.88 tests => 16;
 
 use lib 't/lib';
 
@@ -34,8 +34,8 @@ sub build_tzil {
 # Set responses for the username and password prompts:
 sub set_responses {
   my $chrome = shift->chrome;
-  $chrome->set_response_for("PAUSE username: ",             shift);
-  $chrome->set_response_for("PAUSE password (will echo): ", shift);
+  $chrome->set_response_for('PAUSE username: ', shift);
+  $chrome->set_response_for('PAUSE password: ', shift);
 }
 
 #---------------------------------------------------------------------
@@ -141,6 +141,3 @@ my %safety_first = (qw(upload_uri http://bogus.example.com/do/not/upload/),
     "no release without password"
   );
 }
-
-#---------------------------------------------------------------------
-done_testing;


### PR DESCRIPTION
There's no reason the password should be visible, and it was surprisingly easy to make it hidden.
