### PR TITLE
doc fix for ShareDir

### DIFF
--- a/lib/Dist/Zilla/Plugin/ShareDir.pm
+++ b/lib/Dist/Zilla/Plugin/ShareDir.pm
@@ -11,6 +11,9 @@ use Moose::Autobox;
 In your F<dist.ini>:
 
   [ShareDir]
+  dir = share
+
+  If no C<dir> is provided, the default is F<share>.
 
 =cut
 


### PR DESCRIPTION
I was confused as to how to specify the dir, and then I peeked at the docs/source for ExecDir and all was clear.
