### PR TITLE
Work around dreaded qr//m 5.8 bug in MakeMaker test

### DIFF
--- a/t/plugins/makemaker.t
+++ b/t/plugins/makemaker.t
@@ -74,7 +74,7 @@ use Test::DZil;
 
   my $content = $tzil->slurp_file('build/Makefile.PL');
 
-  like($content, qr/^use 5\.008001;$/m, "normalized the perl version needed");
+  like($content, qr/^use 5\.008001;\s*$/m, "normalized the perl version needed");
 }
 
 done_testing;


### PR DESCRIPTION
Use the same neat trick employed elsewhere in dzil history.

Tested with various perls via `perlbrew exec`.
