### PR TITLE
Refactor MakeMaker for easier subclassing

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+          MakeMaker has been refactored to make it easier to subclass
+          (Thanks, Christopher J. Madsen!)
 
 4.300008  2012-02-16 17:28:34 America/New_York
           work around qr//m bug in 5.8.8 and earlier (thanks, Randy Stauner!)


### PR DESCRIPTION
My MakeMaker::Custom plugin has to use a really nasty hack to collect the default args generated by the MakeMaker plugin.  This refactors it to make that unnecessary.

It also includes @karenetheridge's fix for [RT 74788](https://rt.cpan.org/Public/Bug/Display.html?id=74788) from pull #78.
