### PR TITLE
Add --versions flag to listdeps and authordeps

### DIFF
--- a/lib/Dist/Zilla/App/Command/listdeps.pm
+++ b/lib/Dist/Zilla/App/Command/listdeps.pm
@@ -32,6 +32,7 @@ sub abstract { "print your distribution's prerequisites" }
 sub opt_spec {
   [ 'author', 'include author dependencies' ],
   [ 'missing', 'list only the missing dependencies' ],
+  [ 'versions', 'include version numbers in listing' ]
 }
 
 sub extract_dependencies {
@@ -71,7 +72,9 @@ sub extract_dependencies {
     @required = grep { $is_required->($_) } @required;
   }
 
-  return sort { lc $a cmp lc $b } @required;
+  # my @sorted = sort { lc $a cmp lc $b } @required;
+  my $versions = $req->as_string_hash;
+  return map { $_ => $versions->{$_} } @required;
 }
 
 sub execute {
@@ -82,8 +85,15 @@ sub execute {
   my @phases = qw(build test configure runtime);
   push @phases, 'develop' if $opt->author;
 
-  print "$_\n"
-    for $self->extract_dependencies($self->zilla, \@phases, $opt->missing);
+  my %modules = $self->extract_dependencies($self->zilla, \@phases, $opt->missing);
+
+  if($opt->versions) {
+    for(sort { lc $a cmp $b } keys %modules) {
+      print "$_ = ".$modules{$_}."\n";
+    }
+  } else {
+      print "$_\n" for sort { lc $a cmp lc $b } keys(%modules);
+  }
 }
 
 1;


### PR DESCRIPTION
This patch adds a --versions flag that will add any version information that is included in the dist.ini. It works for listdeps and authordeps.

The authordeps code has changed the most. I tried not to add anything new. I mostly stole implementation details from listdeps. If nothing else the two are more consistent.

My map/grep fu is weak so there might be some cleanups possible in authordeps to make it more concise.

Feedback welcome, Thanks!
