### PR TITLE
dependency updates for dzil plugin issue on 5.8.8

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+          Depend on a more recent version of Config::MVP, which requires a fix
+          in Class::Load to fix detection of plugin compilation errors on
+          perl5.8.8 (see Class::Load Changes file for details.)  (Karen
+          Etheridge)
 
 4.300009  2012-02-21 19:38:29 America/New_York
           PruneCruft also excludes the _Inline/ directory and MYMETA.json

--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,8 @@ parent  = 0 ; used by the AutoPrereq test corpus
 
 Config::MVP::Reader::INI = 2    ; ensure there's a basic config format
 File::ShareDir::Install  = 0.03 ; for EUMM
+Class::Load = 0.17
+Config::MVP = 2.200002
 
 [RemovePrereqs]
 remove = Config ; why isn't this indexed?? -- rjbs, 2011-02-11

--- a/lib/Dist/Zilla/MVP/Section.pm
+++ b/lib/Dist/Zilla/MVP/Section.pm
@@ -5,7 +5,7 @@ extends 'Config::MVP::Section';
 
 use namespace::autoclean;
 
-use Config::MVP::Section 2.200001; # for not-installed error
+use Config::MVP::Section 2.200002; # for not-installed error
 
 use Moose::Autobox;
 


### PR DESCRIPTION
..which depends on a new release of Config::MVP, which contains similar dependency updates.
