### PR TITLE
missing dependency, used by [MetaTests]

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,7 @@ parent  = 0 ; used by the AutoPrereq test corpus
 
 Config::MVP::Reader::INI = 2    ; ensure there's a basic config format
 File::ShareDir::Install  = 0.03 ; for EUMM
+Test::CPAN::Meta = 0
 
 [RemovePrereqs]
 remove = Config ; why isn't this indexed?? -- rjbs, 2011-02-11


### PR DESCRIPTION
I noticed that [MetaTests] used Test::CPAN::Meta, but it wasn't showing up in the metadata as a dependency.
