### PR TITLE
document Test::CPAN::Meta dependency

### DIFF
--- a/lib/Dist/Zilla/Plugin/MetaTests.pm
+++ b/lib/Dist/Zilla/Plugin/MetaTests.pm
@@ -25,7 +25,8 @@ ___[ xt/release/distmeta.t ]___
 #!perl
 
 use Test::More;
+use Class::Load;
 
-eval "use Test::CPAN::Meta";
-plan skip_all => "Test::CPAN::Meta required for testing META.yml" if $@;
+plan skip_all => "Test::CPAN::Meta required for testing META.yml"
+    unless Class::Load::try_load_class('Test::CPAN::Meta');
 meta_yaml_ok();


### PR DESCRIPTION
Followup to https://github.com/rjbs/dist-zilla/pull/90#issuecomment-4678137 -- simply document that this test lib must be installed.

Also replaced the use of eval and checking $@ to using Class::Load, because my knee was twitching.
