### PR TITLE
Fix authordeps regressions

### DIFF
--- a/lib/Dist/Zilla/App/Command/authordeps.pm
+++ b/lib/Dist/Zilla/App/Command/authordeps.pm
@@ -33,14 +33,14 @@ sub execute {
   require Path::Class;
   require Dist::Zilla::Util;
 
-  $self->log(
+  my $deps =
     $self->format_author_deps(
       $self->extract_author_deps(
         Path::Class::dir(defined $opt->root ? $opt->root : '.'),
         $opt->missing,
       ), $opt->versions
-    ),
-  );
+    );
+  $self->log($deps) if $deps;
 
   return;
 }


### PR DESCRIPTION
Fixes regressions that occured in commit b19a767d4c9034ce:
- empty line in output that breaks "dzil authordeps --missing | cpanm"
- lazy loading of dependencies in Dist::Zilla::App::Command::authordeps
