### PR TITLE
Depend on a specific version of CPAN::Meta::Requirements

### DIFF
--- a/lib/Dist/Zilla/Plugin/CPANFile.pm
+++ b/lib/Dist/Zilla/Plugin/CPANFile.pm
@@ -7,6 +7,7 @@ with 'Dist::Zilla::Role::FileGatherer';
 use namespace::autoclean;
 
 use Dist::Zilla::File::FromCode;
+use CPAN::Meta::Requirements 2.120920;
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
'requirements_for_module' was only just added, in version 2.120920
