### PR TITLE
Enforce :version in payload for add_bundle()

### DIFF
--- a/lib/Dist/Zilla/Role/PluginBundle/Easy.pm
+++ b/lib/Dist/Zilla/Role/PluginBundle/Easy.pm
@@ -161,7 +161,11 @@ sub add_bundle {
   my $package = _bundle_class($bundle);
   $payload  ||= {};
 
-  Class::MOP::load_class($package);
+  my $load_opts = {};
+  if( my $v = $payload->{':version'} ){
+    $load_opts->{'-version'} = $v;
+  }
+  Class::MOP::load_class($package, $load_opts);
 
   $bundle = "\@$bundle" unless $bundle =~ /^@/;
 


### PR DESCRIPTION
I'm thrilled that passing `:version` in the plugin config works...
`dist.ini` supports `:version` for bundles...
how about supporting it for bundles added via Easy's `add_bundle`?
