### PR TITLE
Support -TRIAL in versions for [NextRelease]

### DIFF
--- a/lib/Dist/Zilla/Plugin/NextRelease.pm
+++ b/lib/Dist/Zilla/Plugin/NextRelease.pm
@@ -24,6 +24,11 @@ use String::Formatter 0.100680 stringf => {
     },
     t => sub { "\t" },
     n => sub { "\n" },
+    T => sub { $_[0]->zilla->is_trial
+                   ? (defined $_[1] ? $_[1] : '-TRIAL') : '' },
+    V => sub { $_[0]->zilla->version
+                . ($_[0]->zilla->is_trial
+                   ? (defined $_[1] ? $_[1] : '-TRIAL') : '') },
   },
 };
 
@@ -175,11 +180,38 @@ the timezone to use when generating the date;  defaults to I<local>
 
 The module allows the following sprintf-like format codes in the format:
 
-=for :list
-* v - the version of the dist
-* d - the CLDR format for L<DateTime>
-* n - a newline
-* t - a tab
+=over 4
+
+The module allows the following sprintf-like format codes in the format:
+
+=item C<%v>
+
+The distribution version
+
+=item C<%{-TRIAL}T>
+
+Expands to -TRIAL (or any other supplied string) if this is a trial
+release, or the empty string if not.  A bare C<%T> means C<%{-TRIAL}T>.
+
+=item C<%{-TRIAL}V>
+
+Equivalent to C<%v%{-TRIAL}T>, to allow for the application of modifiers such
+as space padding to the entire version string produced.
+
+=item C<%d>
+
+The date of the release.  You can use any CLDR format supported by
+L<DateTime>.
+
+=item C<%n>
+
+a newline
+
+=item C<%t>
+
+a tab
+
+=back
 
 =head1 SEE ALSO
 

--- a/t/plugins/nextrelease.t
+++ b/t/plugins/nextrelease.t
@@ -162,4 +162,56 @@ END_CHANGES
   );
 }
 
+{
+  local $ENV{TRIAL} = 1;
+
+  my $tzil_trial = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/Changes' => $changes,
+        'source/dist.ini' => simple_ini(
+                'GatherDir',
+                [ NextRelease => { format => "%v%T", } ],
+                'FakeRelease',
+        ),
+      },
+    },
+  );
+
+  $tzil_trial->build;
+
+  like(
+    $tzil_trial->slurp_file('build/Changes'),
+    qr{0.001-TRIAL},
+    "adding -TRIAL works",
+  );
+}
+
+{
+  local $ENV{TRIAL} = 1;
+
+  my $tzil_trial = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/Changes' => $changes,
+        'source/dist.ini' => simple_ini(
+                'GatherDir',
+                [ NextRelease => { format => "%-12V ohhai", } ],
+                'FakeRelease',
+        ),
+      },
+    },
+  );
+
+  $tzil_trial->build;
+
+  like(
+    $tzil_trial->slurp_file('build/Changes'),
+    qr{0.001-TRIAL  ohhai},
+    "adding -TRIAL with padding works",
+  );
+}
+
 done_testing;


### PR DESCRIPTION
This probably isn't release-worthy yet (%V is ick), but comments and suggestions welcome...

Adopted the same syntax as from various Git plugins (e.g. [Git::Commit],
except %t was already being used for tab, so switched to %T. ([Git] should
probably adopt %T, as %t for tab is pretty standard.)
Also added %V to allow justification on the combined version-TRIAL string,
although I suspect that String::Formatter can handle this in a better way.
