### PR TITLE
Fix for RT#76305: AutoPrereqs must skip author/release tests from xt/

### DIFF
--- a/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
@@ -140,6 +140,8 @@ sub register_prereqs {
       # parse only perl files
       next unless $file->name =~ /\.(?:pm|pl|t)$/i
                || $file->content =~ /^#!(?:.*)perl(?:$|\s)/;
+      # RT#76305 skip extra tests produced by ExtraTests plugin
+      next if $file->name =~ m{^t/(?:author|release)-[^/]*\.t$};
 
       # store module name, to trim it from require list later on
       my $module = $file->name;

--- a/t/plugins/extratests.t
+++ b/t/plugins/extratests.t
@@ -79,9 +79,10 @@ is_json(
       test => {
         requires => {
           'Test::More' => '0.88',
-          'Foo::author' => '392',
-          'Foo::release' => '392',
           'Foo::smoke' => '392',
+          # Foo::author and Foo::release are
+          # not here because they are not required by the end user
+          # (See RT#76305)
         },
       },
     },


### PR DESCRIPTION
Fixes [RT#76305](https://rt.cpan.org/Ticket/Display.html?id=76305)

First commit adds AutoPrereqs in t/plugins/ExtraTests.t to show the bug.
The second commit fixes AutoPreqs and the test.

Filtering is done only based on the filenames: `^xt/(?:author|release)-[^/]\.t$`
