### PR TITLE
DZ:Util:AuthorDeps: add missing use List::MoreUtils

### DIFF
--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -5,6 +5,7 @@ package Dist::Zilla::Util::AuthorDeps;
 
 use Dist::Zilla::Util;
 use Path::Class;
+use List::MoreUtils ();
 
 
 sub format_author_deps {


### PR DESCRIPTION
`use List::MoreUtils` was missing in my previous (merged) patch for AuthorDeps.
This is not a problem in normal use (dzil authordeps) but it is when using the module standalone (when writing tests for example).
