### PR TITLE
Improve the Plugin::Pod* documentation

### DIFF
--- a/lib/Dist/Zilla/Plugin/PodCoverageTests.pm
+++ b/lib/Dist/Zilla/Plugin/PodCoverageTests.pm
@@ -5,6 +5,14 @@ extends 'Dist::Zilla::Plugin::InlineFiles';
 
 use namespace::autoclean;
 
+=head1 SYNOPSIS
+
+    # Add this line to dist.ini
+    [PodCoverageTests]
+
+    # Run this in the command line to test for POD coverage:
+    $ dzil test --release
+
 =head1 DESCRIPTION
 
 This is an extension of L<Dist::Zilla::Plugin::InlineFiles>, providing the
@@ -17,6 +25,8 @@ means that to indicate that some subs should be treated as covered, even if no
 documentation can be found, you can add:
 
   =for Pod::Coverage sub_name other_sub this_one_too
+
+One can run the release tests by invoking C<dzil test --release>.
 
 =cut
 

--- a/lib/Dist/Zilla/Plugin/PodSyntaxTests.pm
+++ b/lib/Dist/Zilla/Plugin/PodSyntaxTests.pm
@@ -5,12 +5,22 @@ extends 'Dist::Zilla::Plugin::InlineFiles';
 
 use namespace::autoclean;
 
+=head1 SYNTAX
+
+    # Add this to your dist.ini.
+    [PodSyntaxTests]
+
+    # To test for POD validity, run this in the shell:
+    $ dzil test --release
+
 =head1 DESCRIPTION
 
 This is an extension of L<Dist::Zilla::Plugin::InlineFiles>, providing the
 following files:
 
   xt/release/pod-syntax.t   - a standard Test::Pod test
+
+One can run the release tests by invoking C<dzil test --release>.
 
 =cut
 


### PR DESCRIPTION
Per our discussion on IRC: add synopses, and references to "dzil test --release".
