### PR TITLE
RT#79842: PodSyntaxTests now injects Test::Pod dependency

### DIFF
--- a/lib/Dist/Zilla/Plugin/PodSyntaxTests.pm
+++ b/lib/Dist/Zilla/Plugin/PodSyntaxTests.pm
@@ -2,6 +2,7 @@ package Dist::Zilla::Plugin::PodSyntaxTests;
 # ABSTRACT: a release test for Pod syntax
 use Moose;
 extends 'Dist::Zilla::Plugin::InlineFiles';
+with 'Dist::Zilla::Role::PrereqSource';
 
 use namespace::autoclean;
 
@@ -12,7 +13,25 @@ following files:
 
   xt/release/pod-syntax.t   - a standard Test::Pod test
 
+L<Test::Pod> C<1.41> will be added as a C<develop requires> dependency.
+
 =cut
+
+
+# Register the release test prereq as a "develop requires"
+# so it will be listed in "dzil listdeps --author"
+sub register_prereqs {
+  my ($self) = @_;
+
+  $self->zilla->register_prereqs(
+    {
+      type  => 'requires',
+      phase => 'develop',
+    },
+    'Test::Pod' => '1.41',
+  );
+}
+
 
 __PACKAGE__->meta->make_immutable;
 1;

--- a/t/plugins/podsyntaxtests.t
+++ b/t/plugins/podsyntaxtests.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+use Test::Fatal qw(exception);
+
+use lib 't/lib';
+
+use JSON 2;
+use Test::DZil;
+
+{
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          [ GatherDir => ],
+          [ PodSyntaxTests => ],
+          [ MetaJSON  => ],
+        ),
+      },
+    },
+  );
+
+  $tzil->build;
+
+  my $json = $tzil->slurp_file('build/META.json');
+
+  my $meta = JSON->new->decode($json);
+
+  is_deeply(
+    $meta->{prereqs},
+    {
+       develop => { requires => { 'Test::Pod' => '1.41' } },
+    },
+    'PodSyntaxTests develop prereqs'
+  );
+
+  like(
+    $tzil->slurp_file('build/xt/release/pod-syntax.t'),
+    qr/\Quse Test::Pod 1.41/,
+    'xt/release/pod-syntax.t content'
+  );
+}
+
+done_testing;


### PR DESCRIPTION
Fix for [RT#79842](https://rt.cpan.org/Ticket/Display.html?id=79842):  if `[PodSyntaxTests]` is used a `develop requires` dependency on `Test::Pod 1.41` is now injected. So `Test::Pod` will now appear in `dzil listdeps --author`.

As a side effect, Dist-Zilla itself will have that `develop requires` dependency on `Test::Pod` as `[PodSyntaxTests]` is used in `[@RJBS]`.
