### PR TITLE
Add develop requires for MetaTests, with tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
-          PodSyntaxTests and PodCoverageTest now add the right develop/requires
-          prereqs (thanks, Olivier Mengué and Ricardo Signes!)
+          PodSyntaxTests, PodCoverageTests and MetaTests now add the right
+          develop/requires prereqs (thanks, Olivier Mengué and Ricardo Signes!)
 
 4.300025  2012-10-07 23:02:33 America/New_York
           add the LicenseProvider and NameProvider roles (thanks, Vyacheslav

--- a/lib/Dist/Zilla/Plugin/MetaTests.pm
+++ b/lib/Dist/Zilla/Plugin/MetaTests.pm
@@ -2,6 +2,7 @@ package Dist::Zilla::Plugin::MetaTests;
 # ABSTRACT: common extra tests for META.yml
 use Moose;
 extends 'Dist::Zilla::Plugin::InlineFiles';
+with 'Dist::Zilla::Role::PrereqSource';
 
 use namespace::autoclean;
 
@@ -25,6 +26,19 @@ L<MetaJSON|Dist::Zilla::Plugin::MetaJSON>,
 L<MetaConfig|Dist::Zilla::Plugin::MetaConfig>.
 
 =cut
+
+# Register the release test prereq as a "develop requires"
+# so it will be listed in "dzil listdeps --author"
+sub register_prereqs {
+  my ($self) = @_;
+
+  $self->zilla->register_prereqs(
+    {
+      phase => 'develop', type  => 'requires',
+    },
+    'Test::CPAN::Meta'     => 0,
+  );
+}
 
 __PACKAGE__->meta->make_immutable;
 1;

--- a/t/plugins/misctests.t
+++ b/t/plugins/misctests.t
@@ -5,6 +5,7 @@ use Test::More 0.88;
 use lib 't/lib';
 
 use autodie;
+use JSON 2;
 use Test::DZil;
 
 my $tzil = Builder->from_config(
@@ -12,7 +13,7 @@ my $tzil = Builder->from_config(
   {
     add_files => {
       'source/dist.ini' => simple_ini(
-        qw(GatherDir MetaTests PodSyntaxTests PodCoverageTests)
+        qw(GatherDir MetaTests PodSyntaxTests PodCoverageTests MetaJSON)
       ),
     },
   },
@@ -28,5 +29,29 @@ like($pod_test, qr{all_pod_files_ok}, "we have a pod-syntax test");
 
 my $pod_c_test = $tzil->slurp_file('build/xt/release/pod-coverage.t');
 like($pod_c_test, qr{all_pod_coverage_ok}, "we have a pod-coverage test");
+
+my $json = $tzil->slurp_file('build/META.json');
+
+my $meta = JSON->new->decode($json);
+
+is_deeply(
+  $meta->{prereqs},
+  {
+    develop =>
+    {
+      requires =>
+      {
+        # PodSyntaxTests
+        'Test::Pod' => '1.41',
+        # PodCoverageTests
+        'Test::Pod::Coverage'     => '1.08',
+        'Pod::Coverage::TrustPod' => 0,
+        # MetaTests
+        'Test::CPAN::Meta' => 0,
+      },
+    },
+  },
+  'develop prereqs'
+);
 
 done_testing;


### PR DESCRIPTION
As a followup to #123, this patch adds `develop requires` for `[MetaTests]`.
Also tests of the dependency output are added for `MetaTests` and `PodCoverageTests`.
'Changes' is modified accordingly.
