### PR TITLE
Adjust bin/dzil to use /usr/bin/env instead of hardcoding /usr/bin/perl

### DIFF
--- a/bin/dzil
+++ b/bin/dzil
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 package


### PR DESCRIPTION
This should have no impact on existing implementations and allows the binary to work a little bit cleaner when it's both installed on the system and in a perlbrew instance.
