### PR TITLE
Better warning message if no global config file

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -296,7 +296,8 @@ sub _build_license {
     if (@guess != 1) {
       $self->log_fatal(
         "no license data in config, no %Rights stash,",
-        "couldn't make a good guess at license from Pod; giving up"
+        "couldn't make a good guess at license from Pod; giving up. ",
+        "Perhaphs you need set global config file (dzil setup)?"
       );
     }
 


### PR DESCRIPTION
If you haven't run dzil setup the warning message does not provide much information what should you do in order to resolve it.

[DZ] no license data in config, no %Rights stash, couldn't make a good guess at license from Pod; giving up
