### PR TITLE
please remove copyright year from the distini plugin.

### DIFF
--- a/lib/Dist/Zilla/Plugin/DistINI.pm
+++ b/lib/Dist/Zilla/Plugin/DistINI.pm
@@ -42,7 +42,6 @@ like this:
   author  = E. Xavier Ample <example@example.com>
   license = Perl_5
   copyright_holder = E. Xavier Ample
-  copyright_year   = 2010
 
   [@Basic]
   [NextRelease]
@@ -90,7 +89,6 @@ sub gather_files {
     $content .= sprintf "author  = %s\n", $_ for @{ $zilla->authors };
     $content .= sprintf "license = %s\n", $license;
     $content .= sprintf "copyright_holder = %s\n", $zilla->copyright_holder;
-    $content .= sprintf "copyright_year   = %s\n", (localtime)[5] + 1900;
     $content .= "\n";
 
     $content .= $postlude;


### PR DESCRIPTION
using the current year of release is more likely the desired behavior, and
will keep the latest release under copyright longer than old ones.

Signed-off-by: Caleb Cushing <xenoterracide@gmail.com>