### PR TITLE
loosen the constraint on copyright_year

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -347,7 +347,7 @@ has _copyright_holder => (
 
 has _copyright_year => (
   is        => 'ro',
-  isa       => 'Int',
+  isa       => 'Str',
   lazy      => 1,
   init_arg  => 'copyright_year',
   clearer   => '_clear_copyright_year',


### PR DESCRIPTION
given that the value is inserted in a string, and not used in any
computation involving integers, it seems nice to give authors the
option to declare a range of years is they wish to, such as

```
copyright_year = 2010-2012
```
