### PR TITLE
Make dzil test more generic

### DIFF
--- a/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
@@ -5,6 +5,7 @@ use Moose;
 with(
   'Dist::Zilla::Role::BuildRunner',
   'Dist::Zilla::Role::TestRunner',
+  'Dist::Zilla::Role::TestingBase',
 );
 
 use namespace::autoclean;
@@ -32,7 +33,7 @@ sub test {
 
   my $make = $self->make_path;
   $self->build;
-  system($make, 'test',
+  system($make, @{$self->testing_command},
     ( $self->zilla->logger->get_debug ? 'TEST_VERBOSE=1' : () ),
   ) and die "error running $make test\n";
 

--- a/lib/Dist/Zilla/Plugin/PodCoverageTests.pm
+++ b/lib/Dist/Zilla/Plugin/PodCoverageTests.pm
@@ -6,6 +6,14 @@ with 'Dist::Zilla::Role::PrereqSource';
 
 use namespace::autoclean;
 
+=head1 SYNOPSIS
+
+    # Add this line to dist.ini
+    [PodCoverageTests]
+
+    # Run this in the command line to test for POD coverage:
+    $ dzil test --release
+
 =head1 DESCRIPTION
 
 This is an extension of L<Dist::Zilla::Plugin::InlineFiles>, providing the
@@ -18,6 +26,8 @@ means that to indicate that some subs should be treated as covered, even if no
 documentation can be found, you can add:
 
   =for Pod::Coverage sub_name other_sub this_one_too
+
+One can run the release tests by invoking C<dzil test --release>.
 
 =cut
 

--- a/lib/Dist/Zilla/Plugin/PodSyntaxTests.pm
+++ b/lib/Dist/Zilla/Plugin/PodSyntaxTests.pm
@@ -6,6 +6,14 @@ with 'Dist::Zilla::Role::PrereqSource';
 
 use namespace::autoclean;
 
+=head1 SYNTAX
+
+    # Add this to your dist.ini.
+    [PodSyntaxTests]
+
+    # To test for POD validity, run this in the shell:
+    $ dzil test --release
+
 =head1 DESCRIPTION
 
 This is an extension of L<Dist::Zilla::Plugin::InlineFiles>, providing the
@@ -14,6 +22,8 @@ following files:
   xt/release/pod-syntax.t   - a standard Test::Pod test
 
 L<Test::Pod> C<1.41> will be added as a C<develop requires> dependency.
+
+One can run the release tests by invoking C<dzil test --release>.
 
 =cut
 

--- a/lib/Dist/Zilla/Role/BuildPL.pm
+++ b/lib/Dist/Zilla/Role/BuildPL.pm
@@ -5,6 +5,7 @@ with qw(
   Dist::Zilla::Role::InstallTool
   Dist::Zilla::Role::BuildRunner
   Dist::Zilla::Role::TestRunner
+  Dist::Zilla::Role::TestingBase
 );
 
 use namespace::autoclean;
@@ -23,7 +24,7 @@ sub test {
 
   $self->build;
   my @testing = $self->zilla->logger->get_debug ? '--verbose' : ();
-  system $^X, 'Build', 'test', @testing and die "error running $^X Build test\n";
+  system $^X, 'Build', @{$self->testing_command}, @testing and die "error running $^X Build test\n";
 
   return;
 }

--- a/lib/Dist/Zilla/Role/TestingBase.pm
+++ b/lib/Dist/Zilla/Role/TestingBase.pm
@@ -14,12 +14,17 @@ So for example, one can set it to C<runtest> to test using L<Test::Run::CmdLine>
 Defaults to "test".
 =cut
 
-# XXX: Later, add a way to set this in config. -- rjbs, 2008-06-02
+around mvp_multivalue_args => sub {
+  my ($orig, $self) = @_;
+
+  my @start = $self->$orig;
+  return (@start, qw(testing_command));
+};
+
 has testing_command => (
   is   => 'rw',
-  isa  => 'ArrayRef',
+  isa  => 'ArrayRef[Str]',
   lazy => 1,
-  init_arg => undef,
   default  => sub { [ qw( test ) ] },
 );
 

--- a/lib/Dist/Zilla/Role/TestingBase.pm
+++ b/lib/Dist/Zilla/Role/TestingBase.pm
@@ -1,0 +1,35 @@
+package Dist::Zilla::Role::TestingBase;
+# ABSTRACT: Common ground for automated test suites commands
+use Moose::Role;
+
+use namespace::autoclean;
+
+=attr testing_command
+
+This attribute specifies the testing command to use instead of the "test"
+in "./Build test" or "make test". It is an array reference of arguments.
+
+So for example, one can set it to C<runtest> to test using L<Test::Run::CmdLine>.
+
+Defaults to "test".
+=cut
+
+# XXX: Later, add a way to set this in config. -- rjbs, 2008-06-02
+has testing_command => (
+  is   => 'rw',
+  isa  => 'ArrayRef',
+  lazy => 1,
+  init_arg => undef,
+  default  => sub { [ qw( test ) ] },
+);
+
+1;
+
+=head1 DESCRIPTION
+
+This role is a helper for all installers that make use of test suite commands,
+and allows one to specify the L<testing_command> as an arrayref of command-line
+arguments.
+
+=cut
+


### PR DESCRIPTION
These two commits allow to specify a different command to run instead of "test" in "make test" or "./Build test". 