### PR TITLE
ConfirmRelease: remove obsolete code (EUMM loading) and doc

### DIFF
--- a/lib/Dist/Zilla/Plugin/ConfirmRelease.pm
+++ b/lib/Dist/Zilla/Plugin/ConfirmRelease.pm
@@ -5,7 +5,6 @@ with 'Dist::Zilla::Role::BeforeRelease';
 
 use namespace::autoclean;
 
-use ExtUtils::MakeMaker ();
 use Moose::Autobox;
 
 sub before_release {
@@ -42,7 +41,3 @@ they upload.
 The default is "no", but you can set the environment variable
 C<DZIL_CONFIRMRELEASE_DEFAULT> to "yes" if you just want to hit enter to
 release.
-
-This plugin uses C<ExtUtils::MakeMaker::prompt()>, so setting
-C<PERL_MM_USE_DEFAULT> to a true value will accept the default without
-prompting.


### PR DESCRIPTION
ExtUtils::MakeMaker::prompt is not used anymore for the prompt. So we
don't need to load EUMM anymore. One more speed up!

Thanks Devel::NYTProf for the catch!
