### PR TITLE
Load Archive::Tar only when used (in Dist::Builder, Plugin::TestRelease)

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -7,7 +7,6 @@ use Moose::Autobox 0.09; # ->flatten
 use MooseX::Types::Moose qw(HashRef);
 use MooseX::Types::Path::Class qw(Dir File);
 
-use Archive::Tar;
 use File::pushd ();
 use Path::Class;
 use Try::Tiny;
@@ -438,6 +437,7 @@ sub _build_archive {
 
   $self->log("building archive with Archive::Tar; install Archive::Tar::Wrapper for improved speed");
 
+  require Archive::Tar;
   my $archive = Archive::Tar->new;
   my %seen_dir;
   for my $distfile (

--- a/lib/Dist/Zilla/Plugin/TestRelease.pm
+++ b/lib/Dist/Zilla/Plugin/TestRelease.pm
@@ -22,7 +22,6 @@ This plugin was originally contributed by Christopher J. Madsen.
 
 =cut
 
-use Archive::Tar;
 use File::pushd ();
 use Moose::Autobox;
 use Path::Class ();
@@ -37,6 +36,8 @@ sub before_release {
   my $tmpdir = Path::Class::dir( File::Temp::tempdir(DIR => $build_root) );
 
   $self->log("Extracting $tgz to $tmpdir");
+
+  require Archive::Tar;
 
   my @files = do {
     my $wd = File::pushd::pushd($tmpdir);


### PR DESCRIPTION
This patch replaces `use Archive::Tar` with appropriate `require Archive::Tar` in `Dist::Zilla::Dist::Builder` and `Dist::Zilla::Plugin::TestRelease`.
One less module loaded every time.

Thanks to [Devel::TraceUse](https://metacpan.org/module/Devel::TraceUse) for the help:

```
perl -d:TraceUse -Ilib -MDist::Zilla -e '$Dist::Zilla::VERSION=$Dist::Zilla::Plugin::GatherDir::VERSION=4.300030; require "bin/dzil"' nop
```
