### PR TITLE
ManifestSkip: delay loading of ExtUtils::Manifest

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -39,6 +39,7 @@ parent  = 0 ; used by the AutoPrereq test corpus
 File::ShareDir::Install  = 0.03 ; for EUMM
 Class::Load              = 0.17
 Config::MVP::Reader::INI = 2    ; ensure there's a basic config format
+ExtUtils::Manifest       = 1.54 ; for ManifestSkip that needs maniskip()
 
 [RemovePrereqs]
 remove = Config ; why isn't this indexed?? -- rjbs, 2011-02-11

--- a/lib/Dist/Zilla/Plugin/ManifestSkip.pm
+++ b/lib/Dist/Zilla/Plugin/ManifestSkip.pm
@@ -5,7 +5,6 @@ with 'Dist::Zilla::Role::FilePruner';
 
 use namespace::autoclean;
 
-use ExtUtils::Manifest 1.54; # public maniskip routine
 use Moose::Autobox;
 
 =head1 DESCRIPTION
@@ -59,6 +58,9 @@ sub prune_files {
     print $fh $content;
     close $fh;
   }
+
+  require ExtUtils::Manifest;
+  ExtUtils::Manifest->VERSION('1.54');
 
   my $skip = ExtUtils::Manifest::maniskip($skipfile_name);
 


### PR DESCRIPTION
One more lazy loading...

Note that to enforce the ExtUtils::Manifest 1.54 dependency, it is now added explicitely in `dist.ini`. Previously `[AutoPrereqs]` did the job.
