### PR TITLE
no need for a huge stack trace when plugin :version checks fail

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+          stacktrace removed from exception when a plugin's minimum version
+          check fails
 
 4.300030  2013-01-30 22:25:27 America/New_York
           listdeps --versions now sorts properly (thanks, Karen Etheridge!)

--- a/lib/Dist/Zilla/Util.pm
+++ b/lib/Dist/Zilla/Util.pm
@@ -112,8 +112,8 @@ sub _assert_loaded_class_version_ok {
 
   my $have_version = $pkg->VERSION;
   unless ($req->accepts_module($pkg => $have_version)) {
-    Carp::confess( sprintf
-      "%s version (%s) not match required version: %s",
+    die( sprintf
+      "%s version (%s) not match required version: %s\n",
       $pkg,
       $have_version,
       $version,


### PR DESCRIPTION
Before:

```
Dist::Zilla::Plugin::Test::MinimumVersion version (2.000002) not match required version: 2.000003 at /Users/ether/perl5/perlbrew/perls/perl-5.16.2/lib/site_perl/5.16.2/Dist/Zilla/Util.pm line 101, <GEN1> line 70.
        Dist::Zilla::Util::_assert_loaded_class_version_ok('Dist::Zilla::Util', 'Dist::Zilla::Plugin::Test::MinimumVersion', 2.000003) called at /Users/ether/perl5/perlbrew/perls/perl-5.16.2/lib/site_perl/5.16.2/Dist/Zilla/MVP/Section.pm line 29
... 234523423 line snipped...
```

after:

```
Dist::Zilla::Plugin::Test::MinimumVersion version (2.000002) not match required version: 2.000003
```
