### PR TITLE
Support providing abstract with AbstractProvider role

### DIFF
--- a/lib/Dist/Zilla/Role/AbstractProvider.pm
+++ b/lib/Dist/Zilla/Role/AbstractProvider.pm
@@ -1,0 +1,20 @@
+package Dist::Zilla::Role::AbstractProvider;
+# ABSTRACT: something that provides an abstract for the dist
+use Moose::Role;
+with 'Dist::Zilla::Role::Plugin';
+
+=head1 DESCRIPTION
+
+Plugins implementing this role must provide a C<provide_abstract> method that
+will be called when setting the dist's abstract.
+
+If an AbstractProvider offers an abstract but one has already been set, an
+exception will be raised.  If C<provide_abstract> returns undef, it will be
+ignored.
+
+=cut
+
+requires 'provide_abstract';
+
+no Moose::Role;
+1;

--- a/t/lib/Dist/Zilla/Plugin/TestAutoAbstract.pm
+++ b/t/lib/Dist/Zilla/Plugin/TestAutoAbstract.pm
@@ -1,0 +1,15 @@
+package Dist::Zilla::Plugin::TestAutoAbstract;
+
+use Moose;
+with(
+  'Dist::Zilla::Role::AbstractProvider',
+);
+
+sub provide_abstract {
+  my ($self) = @_;
+  return 'Blah blah blah';
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;

--- a/t/plugins/autoabstract.t
+++ b/t/plugins/autoabstract.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+
+use lib 't/lib';
+
+use Test::DZil;
+use YAML::Tiny;
+
+{
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          { abstract => undef },
+          'GatherDir',
+          'TestAutoAbstract',
+        ),
+      },
+    },
+  );
+
+  $tzil->build;
+
+  is($tzil->abstract, 'Blah blah blah', "dist abstract is set (in DZ obj)");
+}
+
+done_testing;


### PR DESCRIPTION
This patch adds AbstractProvider role to the dzil plugin roles and allows plugins to provide dist's attribute instead of the hardcoded default that reads the line "# ABSTRACT: " from the main module, which is left here as a default behavior when there's no provider (and/or no provider returns any abstract info).
