### PR TITLE
fix "latest" symlink

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -596,7 +596,7 @@ sub ensure_built_in_tmpdir {
       rename $latest, $previous
         or $self->log("cannot move .build/latest link to .build/previous");
     }
-    symlink $target, $latest
+    symlink $target->basename, $latest
       or $self->log('cannot create link .build/latest');
   }
 


### PR DESCRIPTION
We were getting links like:
        latest -> .build/deadbeef
    rather than:
        latest -> deadbeef

```
...which were not resolvable.
```
