### PR TITLE
Support TEST_REQUIRES for MakeMaker 6.63_03

### DIFF
--- a/t/plugins/makemaker.t
+++ b/t/plugins/makemaker.t
@@ -40,6 +40,8 @@ use Test::DZil;
     },
     BUILD_REQUIRES     => {
       'Builder::Bob' => '9.901',
+    },
+    TEST_REQUIRES      => {
       'Test::Deet'   => '7',
     },
     CONFIGURE_REQUIRES => {


### PR DESCRIPTION
MakeMaker 6.63_03 accepts `TEST_REQUIRES` and this pull requests takes advantage of that by converting test prereqs into `TEST_REQUIRES`. For earlier versions of MakeMaker it merges it back to `BUILD_REQUIRES` (then `PREREQ_PM`).
