### PR TITLE
Support test_requires for Module::Build 0.4004+

### DIFF
--- a/t/plugins/modulebuild.t
+++ b/t/plugins/modulebuild.t
@@ -44,6 +44,8 @@ use Test::DZil;
     build_requires => {
       'Builder::Bob'  => '9.901',
       'Module::Build' => '0.3601',
+    },
+    test_requires => {
       'Test::Deet'    => '7',
     },
     'configure_requires' => {


### PR DESCRIPTION
Similar to #160 

Module::Build 0.4004 supports `test_requires` (https://github.com/Perl-Toolchain-Gang/Module-Build/pull/11). This patch converts test prereqs to `test_requires` in Module::Build args.

Added the same check as MakeMaker exporter so that if Module::Build is lower than 0.4004 it is merged into `build_requires` in the installation time.
