### PR TITLE
Enables user to configure perl executable used during build and test

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -631,9 +631,10 @@ sub install {
   eval {
     ## no critic Punctuation
     my $wd = File::pushd::pushd($target);
+    my $perl = $ENV{DZIL_PERL} ? $ENV{DZIL_PERL} : $^X;
     my @cmd = $arg->{install_command}
             ? @{ $arg->{install_command} }
-            : ($^X => '-MCPAN' =>
+            : ($perl => '-MCPAN' =>
                 $^O eq 'MSWin32' ? q{-e"install '.'"} : '-einstall "."');
 
     $self->log_debug([ 'installing via %s', \@cmd ]);

--- a/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
@@ -21,8 +21,9 @@ sub build {
   my $self = shift;
 
   my $make = $self->make_path;
-  system($^X => 'Makefile.PL') and die "error with Makefile.PL\n";
-  system($make)                and die "error running $make\n";
+  my $perl = $ENV{DZIL_PERL} ? $ENV{DZIL_PERL} : $^X;
+  system($perl => 'Makefile.PL') and die "error with Makefile.PL\n";
+  system($make)                  and die "error running $make\n";
 
   return;
 }

--- a/lib/Dist/Zilla/Role/BuildPL.pm
+++ b/lib/Dist/Zilla/Role/BuildPL.pm
@@ -12,8 +12,9 @@ use namespace::autoclean;
 sub build {
   my $self = shift;
 
-  system $^X, 'Build.PL' and die "error with Build.PL\n";
-  system $^X, 'Build'    and die "error running $^X Build\n";
+  my $perl = $ENV{DZIL_PERL} ? $ENV{DZIL_PERL} : $^X;
+  system $perl, 'Build.PL' and die "error with Build.PL\n";
+  system $perl, 'Build'    and die "error running $^X Build\n";
 
   return;
 }
@@ -23,7 +24,9 @@ sub test {
 
   $self->build;
   my @testing = $self->zilla->logger->get_debug ? '--verbose' : ();
-  system $^X, 'Build', 'test', @testing and die "error running $^X Build test\n";
+  my $perl = $ENV{DZIL_PERL} ? $ENV{DZIL_PERL} : $^X;
+  system $perl, 'Build', 'test', @testing
+    and die "error running $^X Build test\n";
 
   return;
 }


### PR DESCRIPTION
This patch enables users to configure the which perl executable Dist::Zilla
will use to perform build, test and install actions. It will use the value in
the DZIL_PERL env variable or default to $^X if DZIL_PERL isn't set.

This allows developers to use dzil installed under one version of
perl/local::lib, on projects which require a different version of
perl/local::lib to build/test/install. This has a couple of advantages:

    - you only need to install Dist::Zilla (and plugins and dependencies) once
    - you can keep your active project's installed modules to a minimum, so
      testing dependencies with "rm -rf .local-lib && dzil listdeps | cpanm &&
      dzil test" becomes managable
    - and testing with multiple versions of perl doesn't require a full
      Dist::Zilla toolchain install

If you are receptive to this new config option, I would be happy to update docs
and send pull requests for some of the more popular plugins where $^X is used.
I'm also open to alternative solutions.

I considered implementing as a dzil command line argument, but the env variable
is consistent with local::lib's method of modifying the environment. I don't
believe this should be implemented as a plugin, because it is really developer
specific, not project specific. Most projects expect developers to share a
dist.ini, and if I add

  [PerlExec]
  perl=/home/mgrimes/perl5/perlbrew/perls/perl-5.14-clean/bin/perl

to it is highly unlikely to work for another contributor.