### PR TITLE
move register_stash from Dist::Zilla::MVP::Assembler::Zilla to Dist::Zil...

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Revision history for {{$dist->name}}
           fix docs to not suggest obsolete "Prereq" name (thanks, Ivan
           Bessarabov!)
 
+          the zilla object gets a register_stash method, making it easier for
+          plugins and podweaver sections to share data (Karen Etheridge)
+
 4.300034  2013-04-13 16:56:48 Europe/London
           delay loading of CPAN::Uploader, and require a newer version to
           require HTTPS (thanks, Olivier Mengué!)

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -704,6 +704,24 @@ sub stash_named {
   return $self->_global_stashes->{ $name };
 }
 
+=method register_stash
+
+  $zilla->register_stash($name => $stash_object);
+
+This adds a stash to zilla's stash registry -- unless the name
+is already taken, in which case an exception is raised.
+
+=cut
+
+sub register_stash {
+  my ($self, $name, $object) = @_;
+  $self->log_fatal("tried to register $name stash entry twice")
+    if $self->_local_stashes->{ $name };
+
+  $self->_local_stashes->{ $name } = $object;
+  return;
+}
+
 __PACKAGE__->meta->make_immutable;
 1;
 

--- a/lib/Dist/Zilla/MVP/Assembler/Zilla.pm
+++ b/lib/Dist/Zilla/MVP/Assembler/Zilla.pm
@@ -59,11 +59,7 @@ is already taken, in which case an exception is raised.
 
 sub register_stash {
   my ($self, $name, $object) = @_;
-  $self->log_fatal("tried to register $name stash entry twice")
-    if $self->zilla->_local_stashes->{ $name };
-
-  $self->zilla->_local_stashes->{ $name } = $object;
-  return;
+  $self->zilla->register_stash($name, $object);
 }
 
 __PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
...la, for easier access

This will make what I was trying to do in https://github.com/keedi/Pod-Weaver-Section-Contributors/pull/3 and https://github.com/keedi/Pod-Weaver-Section-Contributors/pull/4 more possible -- it would be somewhat silly to expose the $assembler just to be able to access the stashes that are on $zilla anyway.
