### PR TITLE
Allow for binary files in release build archive

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -458,7 +458,7 @@ sub _build_archive {
     my $content = do {
       use autodie;
       local $/;
-      open my $fh, '<', $filename;
+      open my $fh, '<:raw', $filename;
       <$fh>;
     };
     $archive->add_data(


### PR DESCRIPTION
Open distribution files with ':raw' so that files such as JARs can be copied into the distribution correctly. See http://stackoverflow.com/a/16517259/474819
