### PR TITLE
travis: build against 5.8 and 5.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ perl:
     - "5.16"
     - "5.18"
 
+matrix:
+    allow_failures:
+        - perl: "5.8"
+
 install:
     - cpanm Dist::Zilla
     - dzil authordeps --missing | cpanm || { cat ~/.cpanm/build.log ; false ; }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: perl
 
 perl:
+    - "5.8"
     - "5.10"
     - "5.12"
     - "5.14"
     - "5.16"
+    - "5.18"
 
 install:
     - cpanm Dist::Zilla

--- a/lib/Dist/Zilla/App/Command/install.pm
+++ b/lib/Dist/Zilla/App/Command/install.pm
@@ -34,7 +34,7 @@ Any value that works with L<C<system>|perlfunc/system> is accepted.
 
 If not specified, calls (roughly):
 
-    perl -MCPAN -einstall "."
+    cpanm .
 
 For more information, look at the L<install|Dist::Zilla::Dist::Builder/install> method in
 Dist::Zilla.

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -634,8 +634,7 @@ sub install {
     my $wd = File::pushd::pushd($target);
     my @cmd = $arg->{install_command}
             ? @{ $arg->{install_command} }
-            : ($^X => '-MCPAN' =>
-                $^O eq 'MSWin32' ? q{-e"install '.'"} : '-einstall "."');
+            : (cpanm => ".");
 
     $self->log_debug([ 'installing via %s', \@cmd ]);
     system(@cmd) && $self->log_fatal([ "error running %s", \@cmd ]);

--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -91,6 +91,7 @@ sub munge_perl {
 
   my %seen_pkg;
 
+  my $munged = 0;
   for my $stmt (@$package_stmts) {
     my $package = $stmt->namespace;
 
@@ -122,9 +123,10 @@ sub munge_perl {
     Carp::carp("error inserting version in " . $file->name)
       unless $stmt->insert_after($children[0]->clone)
       and    $stmt->insert_after( PPI::Token::Whitespace->new("\n") );
+    $munged = 1;
   }
 
-  $self->save_ppi_document_to_file($document, $file);
+  $self->save_ppi_document_to_file($document, $file) if $munged;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -62,6 +62,12 @@ sub munge_file {
   return;
 }
 
+has die_on_existing_version => (
+  is  => 'ro',
+  isa => 'Bool',
+  default => 0,
+);
+
 sub munge_perl {
   my ($self, $file) = @_;
 
@@ -73,6 +79,10 @@ sub munge_perl {
   my $document = $self->ppi_document_for_file($file);
 
   if ($self->document_assigns_to_variable($document, '$VERSION')) {
+    if ($self->die_on_existing_version) {
+      $self->log([ 'existing assignment to $VERSION in %s', $file->name ]);
+    }
+
     $self->log([ 'skipping %s: assigns to $VERSION', $file->name ]);
     return;
   }


### PR DESCRIPTION
Travis now supports perls 5.8 and 5.18 natively, so let's take advantage of
that :)

Unfortunately, we cannot build against 5.8 at the moment, but 5.8 is
supported.  So... hm.  We'll need a cleverer solution here, but until then
we can mark the 5.8 build as allowed to fail.