### PR TITLE
PruneCruft: prune fatlib/

### DIFF
--- a/lib/Dist/Zilla/Plugin/PruneCruft.pm
+++ b/lib/Dist/Zilla/Plugin/PruneCruft.pm
@@ -69,6 +69,9 @@ sub exclude_file {
   return 1 if $file->name eq 'MYMETA.yml';
   return 1 if $file->name eq 'MYMETA.json';
   return 1 if $file->name eq 'pm_to_blib';
+  # Avoid bundling fatlib/ dir created by App::FatPacker
+  # https://github.com/andk/pause/pull/65
+  return 1 if substr($file->name, 0, 7) eq 'fatlib/';
 
   if ((my $file = $file->name) =~ s/\.c$//) {
       for my $other ($self->zilla->files->flatten) {


### PR DESCRIPTION
Rationale: some author may build a fatpacked script from his project and that creates a `fatlib/` directory that contains copies of CPAN modules. If that `fatlib/` is bundled in a distribution and indexed by PAUSE, that will hide the original modules on CPAN.
We want to avoid that: bundling `fatlib` by default is always a mistake. If the author really wants that, he can still use explicitely the `exception` feature of `PruneCruft`.

See andk/pause#65
