### PR TITLE
Bug ppi rm pod and comments

### DIFF
--- a/lib/Dist/Zilla/Role/PPI.pm
+++ b/lib/Dist/Zilla/Role/PPI.pm
@@ -7,6 +7,7 @@ use Moose::Util::TypeConstraints;
 use namespace::autoclean;
 
 use Digest::MD5 qw(md5);
+use Storable qw(dclone);
 
 =head1 DESCRIPTION
 
@@ -73,7 +74,20 @@ This method returns true if the document assigns to the given variable.
 =cut
 
 sub document_assigns_to_variable {
-  my ($self, $document, $variable) = @_;
+  my ($self, $orig_document, $variable) = @_;
+
+  # Clone because ppi_document_for_file which the caller is likely to
+  # have retrieved his document from caches aggressively, and we'd
+  # like to prun POD and comments.
+  #
+  # It would be pretty stupid of us to say we found a variable in some
+  # comment or in the POD, which we might do because if the POD is
+  # preceded by __END__ or __DATA__ it'll be a PPI::Statement. So
+  # prune PPI::Statement::* things that we don't want, note that we
+  # don't have to prune e.g. PPI::Token::Pod because of the isa check
+  # in the finder below.
+  my $document = dclone($orig_document);
+  $document->prune($_) for qw(PPI::Statement::End PPI::Statement::Data);
 
   my $finder = sub {
     my $node = $_[1];

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -32,6 +32,22 @@ package DZT::WInComment;
 1;
 ';
 
+my $in_pod_stm = '
+package DZT::WInPODStm;
+
+1;
+
+__END__
+our $VERSION = 1.234;
+=for bug
+
+  # Because we have an __END__ up there PPI considers this a statement
+
+  our $VERSION = 1.234;
+
+=cut
+';
+
 my $two_packages = '
 package DZT::TP1;
 
@@ -89,6 +105,7 @@ my $tzil = Builder->from_config(
       'source/lib/DZT/WVerTwoLines.pm' => $with_version_two_lines,
       'source/lib/DZT/WStrEscaped.pm'  => $in_a_string_escaped,
       'source/lib/DZT/WInComment.pm' => $in_comment,
+      'source/lib/DZT/WInPODStm.pm' => $in_pod_stm,
       'source/lib/DZT/R1.pm'     => $repeated_packages,
       'source/lib/DZT/Monkey.pm' => $monkey_patched,
       'source/lib/DZT/HideMe.pm' => $hide_me_comment,
@@ -141,6 +158,13 @@ like(
   $dzt_wver_in_comment,
   qr{^\s*\$\QDZT::WInComment::VERSION = '0.001';\E\s*$}m,
   "added to DZT::WInComment; the one we have is in a comment",
+);
+
+my $dzt_wver_in_pod_stm = $tzil->slurp_file('build/lib/DZT/WInPODStm.pm');
+like(
+  $dzt_wver_in_pod_stm,
+  qr{^\s*\$\QDZT::WInPODStm::VERSION = '0.001';\E\s*$}m,
+  "added to DZT::WInPODStm; the one we have is in some POD",
 );
 
 my $dzt_wver_str_escaped = $tzil->slurp_file('build/lib/DZT/WStrEscaped.pm');


### PR DESCRIPTION
This fixes a bug that I encountered this morning while trying to release a new distro. PkgVersion should _first_ prune POD and comments before trying to look for $VERSION variables.
