### PR TITLE
FIX: call all builders' build methods to ensure a proper build

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -772,7 +772,7 @@ sub run_in_build {
       return 1;
     }
 
-    $builders[0]->build;
+    $_->build for @builders;
 
     local $ENV{PERL5LIB} = join $Config::Config{path_sep},
       (map { $abstarget->subdir('blib', $_) } qw(arch lib)),


### PR DESCRIPTION
... just as with -TestRunner plugins, we should call all of them, not just the first.

(This situation arises for me when I use both [MakeMaker::Fallback] and [ModuleBuildTiny] in a dist -- the ->build sub in the former is neutered to not do anything.)