### PR TITLE
also attempt to insert $VERSION statements into .pod files

### DIFF
--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -63,7 +63,7 @@ sub munge_file {
   return                          if $file->name    =~ /^corpus\//;
 
   return                          if $file->name    =~ /\.t$/i;
-  return $self->munge_perl($file) if $file->name    =~ /\.(?:pm|pl)$/i;
+  return $self->munge_perl($file) if $file->name    =~ /\.(?:pm|pl|pod)$/i;
   return $self->munge_perl($file) if $file->content =~ /^#!(?:.*)perl(?:$|\s)/;
   return;
 }


### PR DESCRIPTION
If there is no 'package' statement inside, then nothing happens, so it should
be safe to run this on files that contain no valid perl at all, as well as
those with just a 'package' declaration followed by pod
