### PR TITLE
Role::PPI: Pump characters through the File object.

### DIFF
--- a/lib/Dist/Zilla/Role/PPI.pm
+++ b/lib/Dist/Zilla/Role/PPI.pm
@@ -60,9 +60,10 @@ sub save_ppi_document_to_file {
 
   my $new_content = $document->serialize;
 
-  $CACHE{ md5($new_content) } = $document;
-
   $file->content($new_content);
+
+  $CACHE{ md5($file->encoded_content) } = $document;
+
 }
 
 =method document_assigns_to_variable


### PR DESCRIPTION
Saving to the file object prior to storing in the cache,
means we can ask the file object for the bytes version of whatever was
stored there, and use that to generate the same MD5 that was generated
in the ppi_document_for_file method.

( Fixes bug #236 for me )
