### PR TITLE
Fix call to plugins_with

### DIFF
--- a/lib/Dist/Zilla/App/Command/listdeps.pm
+++ b/lib/Dist/Zilla/App/Command/listdeps.pm
@@ -58,7 +58,7 @@ sub prereqs {
 
   $_->before_build for @{ $zilla->plugins_with(-BeforeBuild) };
   $_->gather_files for @{ $zilla->plugins_with(-FileGatherer) };
-  $_->set_file_encodings for @{ $self->plugins_with(-EncodingProvider) };
+  $_->set_file_encodings for @{ $zilla->plugins_with(-EncodingProvider) };
   $_->prune_files  for @{ $zilla->plugins_with(-FilePruner) };
   $_->munge_files  for @{ $zilla->plugins_with(-FileMunger) };
   $_->register_prereqs for @{ $zilla->plugins_with(-PrereqSource) };


### PR DESCRIPTION
Resolves: Can't locate object method "plugins_with" via package "Dist::Zilla::App::Command::listdeps" at /Users/ether/.perlbrew/libs/19.5@std/lib/perl5/Dist/Zilla/App/Command/listdeps.pm line 27, <DATA> line 123.

Clearly the listdeps command needs some tests ;)
