### PR TITLE
Propagate exit code of dzil install

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -642,7 +642,7 @@ sub install {
 
   if ($@) {
     $self->log($@);
-    $self->log("left failed dist in place at $target");
+    $self->log_fatal("left failed dist in place at $target");
   } else {
     $self->log("all's well; removing $target");
     $target->rmtree;


### PR DESCRIPTION
When the install command for dzil install fails an exception is
thrown. An eval captures this exception but does not rethrow it. Thus,
even an unsuccessful dzil install exits with code 0.

This patch logs the exception with log_fatal and thus dies in case of an
exception. This will set an exit code signaling an error.
