### PR TITLE
munge all found files in [PkgVersion], not a subset

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ Revision history for {{$dist->name}}
         - Archive::Tar::Wrapper added as a recommended prereq
         - fix :ShareFiles (thanks, Christopher J. Madsen and Karen Etheridge)
         - new :All and :None filefinders
+        - document the use of filefinders in [PkgVersion], and remove
+          filtering out of .t, .pod files
 
 5.006     2013-11-06 09:21:12 America/New_York
         - add ->is_bytes to files; shortcut for ->encoding eq 'bytes'

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -74,6 +74,19 @@ my $script_pkg = '
 package DZT::Script;
 ';
 
+my $pod_with_pkg = '
+package DZT::PodWithPackage;
+=pod
+
+=cut
+';
+
+my $pod_no_pkg = '
+=pod
+
+=cut
+';
+
 my $tzil = Builder->from_config(
   { dist_root => 'corpus/dist/DZT' },
   {
@@ -85,6 +98,8 @@ my $tzil = Builder->from_config(
       'source/lib/DZT/R1.pm'     => $repeated_packages,
       'source/lib/DZT/Monkey.pm' => $monkey_patched,
       'source/lib/DZT/HideMe.pm' => $hide_me_comment,
+      'source/lib/DZT/PodWithPackage.pm' => $pod_with_pkg,
+      'source/lib/DZT/PodNoPackage.pm' => $pod_no_pkg,
       'source/bin/script_pkg.pl' => $script_pkg,
       'source/bin/script_ver.pl' => $script_pkg . "our \$VERSION = 1.234;\n",
       'source/bin/script.pl'     => $script,
@@ -187,6 +202,20 @@ unlike(
   $dzt_hideme,
   qr{\$DZT::TP2::VERSION},
   "no version for DZT::TP2 when it was hidden with a comment"
+);
+
+my $dzt_podwithpackage = $tzil->slurp_file('build/lib/DZT/PodWithPackage.pm');
+like(
+  $dzt_podwithpackage,
+  qr{^\s*\$\QDZT::PodWithPackage::VERSION = '0.001';\E\s*$}m,
+  "added version to DZT::PodWithPackage",
+);
+
+my $dzt_podnopackage = $tzil->slurp_file('build/lib/DZT/PodNoPackage.pm');
+unlike(
+  $dzt_podnopackage,
+  qr{VERSION},
+  "no version for pod files with no package declaration"
 );
 
 {


### PR DESCRIPTION
A filefinder was already being used, but undocumented.  Also only .pm/.pl
files (or files with a shebang) were being munged, which excludes .pod files
-- only files with a package declaration will be modified, as before.

Closes PRs #219 and #233.
