### PR TITLE
add ->has_encoding to files

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for {{$dist->name}}
         - add the ability to say "dzil run --no-build" to run a command without
           building inside the dist dir
           (in other words, no `perl Makefile.PL && make`)
+        - add ->has_encoding to files (thanks, Christopher J. Madsen)
         - Archive::Tar::Wrapper added as a recommended prereq
 
 5.006     2013-11-06 09:21:12 America/New_York

--- a/lib/Dist/Zilla/File/FromCode.pm
+++ b/lib/Dist/Zilla/File/FromCode.pm
@@ -50,6 +50,8 @@ has encoding => (
   builder => "_build_encoding",
 );
 
+sub has_encoding { 1 } # You can't change the encoding of a FromCode file
+
 sub _build_encoding {
   my ($self) = @_;
   return $self->code_return_type eq 'text' ? 'UTF-8' : 'bytes';

--- a/lib/Dist/Zilla/Role/File.pm
+++ b/lib/Dist/Zilla/Role/File.pm
@@ -59,6 +59,7 @@ has mode => (
 );
 
 requires 'encoding';
+requires 'has_encoding';
 requires 'content';
 requires 'encoded_content';
 

--- a/lib/Dist/Zilla/Role/MutableFile.pm
+++ b/lib/Dist/Zilla/Role/MutableFile.pm
@@ -25,8 +25,17 @@ has encoding => (
   isa         => 'Str',
   lazy        => 1,
   default     => 'UTF-8',
+  predicate   => '_has_encoding',
   traits      => [ qw(SetOnce) ],
 );
+
+sub has_encoding {
+  my $self = shift;
+
+  # If the content source is 'content', then calling ->encoded_content
+  # will set the encoding.  So we'll pretend that it's already set.
+  return $self->_has_encoding || $self->_content_source eq 'content';
+}
 
 =attr content
 


### PR DESCRIPTION
This allows an EncodingProvider to tell whether it makes sense for it to examine the encoded_content and set the encoding.
