### PR TITLE
die with helpful error if encoding cannot be determined

### DIFF
--- a/lib/Dist/Zilla/Chrome/Term.pm
+++ b/lib/Dist/Zilla/Chrome/Term.pm
@@ -53,7 +53,7 @@ has term_enc => (
   lazy => 1,
   default => sub {
     require Term::Encoding;
-    return Term::Encoding::get_encoding();
+    return Term::Encoding::get_encoding() || die 'cannot determine encoding: no locale set?';
   },
 );
 


### PR DESCRIPTION
we cannot use the logger as we need to have the encoding first.
