### PR TITLE
add ->has_encoding & ->is_encoded_content to files

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
         - load DateTime lazily
+	- add ->has_encoding & ->is_encoded_content to files
+	  (thanks, Christopher J. Madsen)
 
 5.019     2014-05-20 21:11:47-04:00 America/New_York
         - remove a very brief-lived attempt to double-decode

--- a/lib/Dist/Zilla/File/FromCode.pm
+++ b/lib/Dist/Zilla/File/FromCode.pm
@@ -38,6 +38,8 @@ has code_return_type => (
   default => 'text',
 );
 
+sub is_encoded_content { shift->code_return_type eq 'bytes' }
+
 =attr encoding
 
 =cut
@@ -50,6 +52,8 @@ has encoding => (
   lazy => 1,
   builder => "_build_encoding",
 );
+
+sub has_encoding { 1 } # You can't change the encoding of a FromCode file
 
 sub _build_encoding {
   my ($self) = @_;

--- a/lib/Dist/Zilla/Role/File.pm
+++ b/lib/Dist/Zilla/Role/File.pm
@@ -60,8 +60,10 @@ has mode => (
 );
 
 requires 'encoding';
+requires 'has_encoding';
 requires 'content';
 requires 'encoded_content';
+requires 'is_encoded_content';
 
 =method is_bytes
 

--- a/lib/Dist/Zilla/Role/MutableFile.pm
+++ b/lib/Dist/Zilla/Role/MutableFile.pm
@@ -20,12 +20,14 @@ Default is 'UTF-8'. Can only be set once.
 with 'Dist::Zilla::Role::File';
 
 sub encoding;
+sub has_encoding;
 
 has encoding => (
   is          => 'rw',
   isa         => 'Str',
   lazy        => 1,
   default     => 'UTF-8',
+  predicate   => 'has_encoding',
   traits      => [ qw(SetOnce) ],
 );
 
@@ -99,6 +101,8 @@ has _content_source => (
     lazy => 1,
     builder => '_build_content_source',
 );
+
+sub is_encoded_content { shift->_content_source eq 'encoded_content' }
 
 sub _update_by {
   my ($self, $attr, $from) = @_;


### PR DESCRIPTION
This is a followup to #254.  In this version, `has_encoding` acts as a normal Moose predicate (except for `FromCode` files, where it always returns true because the encoding attribute is read-only).  The new method `is_encoded_content` indicates whether the "canonical" version is `encoded_content` or `content`.

If you're happy with this, I'll write up some docs.

The idea is that an EncodingProvider can use `has_encoding` to determine whether it's possible to set the encoding, and then use `is_encoded_content` to decide whether it can examine the file to determine an encoding.
