### PR TITLE
include the filename in this warning, to remove confusion when there are...

### DIFF
--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -221,8 +221,9 @@ sub munge_perl {
     } else {
       my $method = $self->die_on_line_insertion ? 'log_fatal' : 'log';
       $self->$method([
-        'no blank line for $VERSION after package %s statement on line %s',
+        'no blank line for $VERSION after package %s statement in %s line %s',
         $stmt->namespace,
+        $file->name,
         $stmt->line_number,
       ]);
 


### PR DESCRIPTION
... multiple packages in a file