### PR TITLE
Eliminate Path::Class

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,7 +40,7 @@ Config::MVP::Reader::INI = 2        ; ensure there's a basic config format
 Data::Section            = 0.200000 ; default encodings to UTF-8
 ExtUtils::Manifest       = 1.54     ; for ManifestSkip that needs maniskip()
 Mixin::Linewise::Readers = 0.100    ; default encodings to UTF-8
-Path::Class              = 0.22     ; basename
+; Path::Class              = 0.22     ; basename
 
 DateTime = 0.44 ; CLDR fixes, used by AutoVersion and NextRelease
 

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -14,7 +14,6 @@ use Moose::Util::TypeConstraints;
 use Dist::Zilla::Types qw(License ReleaseStatus);
 
 use Log::Dispatchouli 1.100712; # proxy_loggers, quiet_fatal
-use Path::Class;
 use Dist::Zilla::Path;
 use List::Util 1.33 qw(first none);
 use Software::License 0.101370; # meta2_name
@@ -725,10 +724,10 @@ sub _write_out_file {
   # Okay, this is a bit much, until we have ->debug. -- rjbs, 2008-06-13
   # $self->log("writing out " . $file->name);
 
-  my $file_path = file($file->name);
+  my $file_path = path($file->name);
 
-  my $to_dir = $build_root->subdir( $file_path->dir );
-  my $to = $to_dir->file( $file_path->basename );
+  my $to_dir = path($build_root)->child( $file_path->parent );
+  my $to = $to_dir->child( $file_path->basename );
   $to_dir->mkpath unless -e $to_dir;
   die "not a directory: $to_dir" unless -d $to_dir;
 

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -15,7 +15,7 @@ use Dist::Zilla::Types qw(License ReleaseStatus);
 
 use Log::Dispatchouli 1.100712; # proxy_loggers, quiet_fatal
 use Path::Class;
-use Path::Tiny;
+use Dist::Zilla::Path;
 use List::Util 1.33 qw(first none);
 use Software::License 0.101370; # meta2_name
 use String::RewritePrefix;

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -8,7 +8,7 @@ with 'Dist::Zilla::Role::ConfigDumper';
 
 use MooseX::Types::Moose qw(ArrayRef Bool HashRef Object Str);
 use MooseX::Types::Perl qw(DistName LaxVersionStr);
-use MooseX::Types::Path::Class qw(Dir File);
+use Dist::Zilla::Types::Path qw(Dir File);
 use Moose::Util::TypeConstraints;
 
 use Dist::Zilla::Types qw(License ReleaseStatus);

--- a/lib/Dist/Zilla/App.pm
+++ b/lib/Dist/Zilla/App.pm
@@ -30,7 +30,7 @@ sub _build_global_stashes {
   require Dist::Zilla::Util;
   my $config_dir  = Dist::Zilla::Util->_global_config_root;
 
-  my $config_base = $config_dir->file('config');
+  my $config_base = $config_dir->child('config');
 
   require Dist::Zilla::MVP::Reader::Finder;
   require Dist::Zilla::MVP::Assembler::GlobalConfig;

--- a/lib/Dist/Zilla/App/Command/add.pm
+++ b/lib/Dist/Zilla/App/Command/add.pm
@@ -4,6 +4,7 @@ package Dist::Zilla::App::Command::add;
 # ABSTRACT: add a module to a dist
 
 use Dist::Zilla::App -command;
+use Dist::Zilla::Path;
 
 =head1 SYNOPSIS
 
@@ -48,8 +49,7 @@ sub execute {
 
   my $zilla = $self->zilla;
   my $dist = $zilla->name;
-
-  require Path::Class;
+  
   require File::pushd;
 
   require Dist::Zilla::Dist::Minter;
@@ -62,7 +62,7 @@ sub execute {
     },
   );
 
-  my $root = Path::Class::dir($zilla->root)->absolute;
+  my $root = path($zilla->root)->absolute;
   my $wd = File::pushd::pushd($minter->root);
 
   my $factory = $minter->plugin_named(':DefaultModuleMaker');

--- a/lib/Dist/Zilla/App/Command/authordeps.pm
+++ b/lib/Dist/Zilla/App/Command/authordeps.pm
@@ -31,13 +31,13 @@ sub opt_spec {
 sub execute {
   my ($self, $opt, $arg) = @_;
 
-  require Path::Class;
+  require Dist::Zilla::Path;
   require Dist::Zilla::Util::AuthorDeps;
 
   my $deps =
     Dist::Zilla::Util::AuthorDeps::format_author_deps(
       Dist::Zilla::Util::AuthorDeps::extract_author_deps(
-        Path::Class::dir(defined $opt->root ? $opt->root : '.'),
+        Dist::Zilla::Path::path(defined $opt->root ? $opt->root : '.'),
         $opt->missing,
       ), $opt->versions
     );

--- a/lib/Dist/Zilla/App/Command/setup.pm
+++ b/lib/Dist/Zilla/App/Command/setup.pm
@@ -123,12 +123,12 @@ Do you want to enter your PAUSE account details? ',
   }
 
   $config_root->mkpath unless -d $config_root;
-  $config_root->subdir('profiles')->mkpath
-    unless -d $config_root->subdir('profiles');
+  $config_root->child('profiles')->mkpath
+    unless -d $config_root->child('profiles');
 
   my $umask = umask;
   umask( $umask | 077 ); # this file might contain PAUSE pw; make it go-r
-  open my $fh, '>:encoding(UTF-8)', $config_root->file('config.ini');
+  open my $fh, '>:encoding(UTF-8)', $config_root->child('config.ini');
 
   $fh->print("[%User]\n");
   $fh->print("name  = $realname\n");

--- a/lib/Dist/Zilla/App/Tester.pm
+++ b/lib/Dist/Zilla/App/Tester.pm
@@ -11,7 +11,7 @@ use File::Copy::Recursive qw(dircopy);
 use File::pushd ();
 use File::Spec;
 use File::Temp;
-use Path::Class;
+use Dist::Zilla::Path;
 
 use Sub::Exporter::Util ();
 use Sub::Exporter -setup => {
@@ -28,7 +28,7 @@ sub test_dzil {
   local @INC = map {; File::Spec->rel2abs($_) } @INC;
 
   my $tmpdir = $arg->{tempdir} || File::Temp::tempdir(CLEANUP => 1);
-  my $root   = dir($tmpdir)->subdir('source');
+  my $root   = path($tmpdir)->child('source');
   $root->mkpath;
 
   dircopy($source, $root);

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -357,6 +357,7 @@ has built_in => (
   is   => 'rw',
   isa  => Dir,
   init_arg  => undef,
+  coerce => 1,
 );
 
 =method ensure_built_in

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -5,7 +5,7 @@ use Moose 0.92; # role composition fixes
 extends 'Dist::Zilla';
 
 use MooseX::Types::Moose qw(HashRef);
-use MooseX::Types::Path::Class qw(Dir File);
+use Dist::Zilla::Types::Path qw(Dir File);
 
 use File::pushd ();
 use Path::Class;

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -472,7 +472,7 @@ sub _build_archive {
   for my $distfile (
     sort { length($a->name) <=> length($b->name) } @{ $self->files }
   ) {
-    my $in = path($distfile->name)->dir;
+    my $in = path($distfile->name)->parent;
 
     unless ($seen_dir{ $in }++) {
       $archive->add_data(
@@ -674,7 +674,7 @@ sub install {
     $self->log("all's well; left dist in place at $target");
   } else {
     $self->log("all's well; removing $target");
-    $target->rmtree;
+    $target->remove_tree;
     $latest->remove if $latest;
   }
 
@@ -788,7 +788,7 @@ sub run_in_build {
 
   if ($ok) {
     $self->log("all's well; removing $target");
-    $target->rmtree;
+    $target->remove_tree;
     $latest->remove if $latest;
   } else {
     my $error = $@ || '(unknown error)';

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -9,7 +9,7 @@ use MooseX::Types::Path::Class qw(Dir File);
 
 use File::pushd ();
 use Path::Class;
-use Path::Tiny; # because more Path::* is better, eh?
+use Dist::Zilla::Path; # because more Path::* is better, eh?
 use Try::Tiny;
 
 use namespace::autoclean;

--- a/lib/Dist/Zilla/Dist/Minter.pm
+++ b/lib/Dist/Zilla/Dist/Minter.pm
@@ -5,7 +5,7 @@ use Moose 0.92; # role composition fixes
 extends 'Dist::Zilla';
 
 use File::pushd ();
-use Path::Class;
+use Dist::Zilla::Path;
 
 use namespace::autoclean;
 
@@ -62,7 +62,7 @@ sub _new_from_profile {
   $assembler->sequence->section_named('_')->add_value(root => $profile_dir);
 
   my $seq = $config_class->read_config(
-    $profile_dir->file('profile'),
+    $profile_dir->child('profile'),
     {
       assembler => $assembler
     },
@@ -79,7 +79,7 @@ sub _mint_target_dir {
   my ($self) = @_;
 
   my $name = $self->name;
-  my $dir  = dir($name);
+  my $dir  = path($name);
   $self->log_fatal("./$name already exists") if -e $dir;
 
   return $dir = $dir->absolute;

--- a/lib/Dist/Zilla/Dist/Minter.pm
+++ b/lib/Dist/Zilla/Dist/Minter.pm
@@ -59,6 +59,9 @@ sub _new_from_profile {
 
   my $profile_dir = $module->profile_dir($profile_data->[1]);
 
+  # TODO: Some warning code here to report $module for returning a Path::Class
+  $profile_dir = Dist::Zilla::Path::path( $profile_dir );
+
   $assembler->sequence->section_named('_')->add_value(root => $profile_dir);
 
   my $seq = $config_class->read_config(

--- a/lib/Dist/Zilla/File/OnDisk.pm
+++ b/lib/Dist/Zilla/File/OnDisk.pm
@@ -3,7 +3,7 @@ package Dist::Zilla::File::OnDisk;
 
 use Moose;
 
-use Path::Tiny;
+use Dist::Zilla::Path;
 
 use namespace::autoclean;
 

--- a/lib/Dist/Zilla/MintingProfile/Default.pm
+++ b/lib/Dist/Zilla/MintingProfile/Default.pm
@@ -7,7 +7,6 @@ with 'Dist::Zilla::Role::MintingProfile::ShareDir';
 use namespace::autoclean;
 
 use Dist::Zilla::Util;
-use Path::Class;
 
 =head1 DESCRIPTION
 
@@ -26,7 +25,7 @@ around profile_dir => sub {
   # shouldn't look in user's config when testing
   if (!$ENV{DZIL_TESTING}) {
     my $profile_dir = Dist::Zilla::Util->_global_config_root
-                    ->subdir('profiles', $profile_name);
+                    ->child('profiles', $profile_name);
 
     return $profile_dir if -d $profile_dir;
   }

--- a/lib/Dist/Zilla/Path.pm
+++ b/lib/Dist/Zilla/Path.pm
@@ -1,0 +1,171 @@
+use strict;
+use warnings;
+use utf8;
+
+package Dist::Zilla::Path;
+
+# ABSTRACT: Wrapper for Path::Tiny that provides backcompat and deprecation process for Path::Class
+
+use Path::Tiny qw();
+use Scalar::Util qw( blessed );
+use Sub::Exporter::Progressive -setup => {
+    exports => [qw[ path  ]],
+    groups  => {
+        default => [qw[ path ]],
+    }
+};
+
+=head1 DESCRIPTION
+
+This module exists to serve as a porting intermediary stage to help transition
+between L<< C<Path::Class>|Path::Class >> and L<< C<Path::Tiny>|Path::Tiny >>
+by responding to all the methods of both.
+
+Each and every method of C<Path::Tiny> is wrapped, and those that normally
+return C<Path::Tiny> objects instead return C<Dist::Zilla::Path> objects.
+
+And each method provided by C<Path::Class::File> and C<Path::Class::Dir> are
+similarly proxied, and the return values re-wrapped as C<Dist::Zilla::Path>
+objects where ever it makes sense.
+
+However, for C<Path::Class> based methods, warnings are emitted indicating their
+short lived future.
+
+This means every place in the C<Dist::Zilla> tree that expects C<Path::Class>
+interfaces will still work, albeit with warnings.
+
+And places that expect C<Path::Tiny> interfaces will keep working as they did
+before.
+
+And your code is encouraged to switch to C<Path::Tiny> wherever possible.
+
+However, if you encounter non-dzil interfaces that may never switch, now is a
+good time to explicitly wrap C<Dist::Zilla::Path> responses before handing
+them over.
+
+    my $value = $dzilla->thing_that_returns_dz_path();
+    Path::Class::Dir->new( $value );
+    $otherapi->method( Path::Class::Dir->new( $value ) );
+
+=cut
+
+use constant { PATH => 0, };
+
+use overload (
+    q{""}    => sub    { $_[0]->[PATH] },
+    bool     => sub () { 1 },
+    fallback => 1,
+);
+
+# Why do these filters only rebless
+# if by regexing the return value?
+#
+# path()->stat # is why.
+
+# Filter objects that are Path::Class or Path::Tiny
+# coerce them to be Path::Tiny then rebless them as Dist::Zilla::Paths
+sub _recast {
+    my ($object) = @_;
+    return $object unless blessed $object;
+    return $object unless ( blessed $object ) =~ /^Path::(Tiny|Class)/;
+    return path($object);
+}
+
+sub AUTOLOAD_dir {
+    my ( $method, $self, @args ) = @_;
+    if (wantarray) {
+        return map { _recast($_) } Path::Class::Dir->new($self)->$method(@args);
+    }
+    return _recast( scalar Path::Class::Dir->new($self)->$method(@args) );
+}
+
+sub AUTOLOAD_file {
+    my ( $method, $self, @args ) = @_;
+    if (wantarray) {
+        return
+          map { _recast($_) } Path::Class::File->new($self)->$method(@args);
+    }
+    return _recast( scalar Path::Class::File->new($self)->$method(@args) );
+}
+
+sub AUTOLOAD_path {
+    my ( $method, $self, @args ) = @_;
+    if (wantarray) {
+        return map { _recast($_) } Path::Tiny::path($self)->$method(@args);
+    }
+    return _recast( scalar Path::Tiny::path($self)->$method(@args) );
+}
+
+# This could have been implemented differently without autoload,
+# but it would have required `require`ing all PT/PCD/PCF, loading Package::Stash,
+# iterating all their symbol tables, dynamically creating subs in ::Path that curried the results
+# from the relevant calls, etc, etc.
+#
+# And that would have also made it impossible to test with
+# PERL5OPT="-MDevel::Hide=Path::Class,Path::Class::File,Path::Class::Dir"
+#
+# So ah, no. Instead, this is a custom dispatch table of some kind.
+#
+sub AUTOLOAD {
+    my $self = shift;
+    ( my $meth = our $AUTOLOAD ) =~ s/.+:://;
+    return if $meth eq 'DESTROY';
+
+    # If the method is Path::Tiny supported,
+    # call it, and wrap the result.
+    return AUTOLOAD_path( $meth, $self, @_ ) if Path::Tiny->can($meth);
+    require Carp;
+    Carp::carp( "$meth called on Dist::Zilla::Path."
+          . ' This is deprecated and will go away in a future release' );
+
+    require Module::Runtime;
+    for my $module ( qw( Path::Class::Dir Path::Class::File ) ) {
+        Module::Runtime::require_module( $module );
+    }
+
+    # Otherwise:
+    # If the method is provided by /both/ PC:D and PC:F, construct
+    # a copy of the most sensible one, call the method,
+    # and return the re-wrapped result.
+
+    if ( Path::Class::Dir->can($meth) and Path::Class::File->can($meth) ) {
+        if ( -d $self ) {
+            return AUTOLOAD_dir( $meth, $self, @_ );
+        }
+        return AUTOLOAD_file( $meth, $self, @_ );
+    }
+
+    # However, if the method is provided by only one of the two,
+    # dispatch and wrap to the right one.
+    #
+    # This is kinda dodgy because essentially, it conflates both
+    # method types into the same object so things like $dir->filemethod()
+    # and $file->dirmethod() are legal however, thats standard for Path::Tiny
+    # anyway.
+    return AUTOLOAD_dir( $meth, $self, @_ ) if Path::Class::Dir->can($meth);
+    return AUTOLOAD_file( $meth, $self, @_ ) if Path::Class::File->can($meth);
+    Carp::croak( "Can't find resolvant for $meth in any of"
+          . ' Path::Tiny, Path::Class::Dir, Path::Class::File' );
+}
+
+=head1 FUNCTIONS
+
+=head2 C<path>
+
+    use Dist::Zilla::Path;
+
+    my $path = path('./');
+
+The exact semantics are otherwise detailed in L<< C<Path::Tiny>|Path::Tiny >>.
+
+Function returns a C<Dist::Zilla::Path> object.
+
+=cut
+
+sub path {
+    my $pp = Path::Tiny::path(@_);
+    return bless $pp, __PACKAGE__;
+}
+
+1;
+

--- a/lib/Dist/Zilla/Path.pm
+++ b/lib/Dist/Zilla/Path.pm
@@ -96,6 +96,9 @@ sub AUTOLOAD_path {
     return _recast( scalar Path::Tiny::path($self)->$method(@args) );
 }
 
+our $WARN_LOAD_PATHCLASS_METHODS = 1;
+our $WARN_REROUTED_METHODS       = undef;
+
 # This could have been implemented differently without autoload,
 # but it would have required `require`ing all PT/PCD/PCF, loading Package::Stash,
 # iterating all their symbol tables, dynamically creating subs in ::Path that curried the results
@@ -114,10 +117,11 @@ sub AUTOLOAD {
     # If the method is Path::Tiny supported,
     # call it, and wrap the result.
     return AUTOLOAD_path( $meth, $self, @_ ) if Path::Tiny->can($meth);
-    require Carp;
-    Carp::carp( "$meth called on Dist::Zilla::Path."
+    if ( $WARN_LOAD_PATHCLASS_METHODS ) {
+        require Carp;
+        Carp::carp( "$meth called on Dist::Zilla::Path."
           . ' This is deprecated and will go away in a future release' );
-
+    }
     require Module::Runtime;
     for my $module ( qw( Path::Class::Dir Path::Class::File ) ) {
         Module::Runtime::require_module( $module );
@@ -144,6 +148,7 @@ sub AUTOLOAD {
     # anyway.
     return AUTOLOAD_dir( $meth, $self, @_ ) if Path::Class::Dir->can($meth);
     return AUTOLOAD_file( $meth, $self, @_ ) if Path::Class::File->can($meth);
+    require Carp;
     Carp::croak( "Can't find resolvant for $meth in any of"
           . ' Path::Tiny, Path::Class::Dir, Path::Class::File' );
 }
@@ -165,6 +170,37 @@ Function returns a C<Dist::Zilla::Path> object.
 sub path {
     my $pp = Path::Tiny::path(@_);
     return bless $pp, __PACKAGE__;
+}
+
+
+sub file {
+    my ( $self, @rest ) = @_;
+    if ( $WARN_REROUTED_METHODS ) {
+        require Carp;
+        Carp::carp( "file called on Dist::Zilla::Path."
+          . ' This is deprecated and will go away in a future release' );
+    }
+    return $self->child( @rest );
+}
+
+sub subdir {
+    my ( $self, @rest ) = @_;
+    if ( $WARN_REROUTED_METHODS ) {
+        require Carp;
+        Carp::carp( "subdir called on Dist::Zilla::Path."
+          . ' This is deprecated and will go away in a future release' );
+    }
+    return $self->child( @rest );
+}
+
+sub dir {
+    my ( $self, @rest ) = @_;
+    if ( $WARN_REROUTED_METHODS ) {
+        require Carp;
+        Carp::carp( "dir called on Dist::Zilla::Path."
+          . ' This is deprecated and will go away in a future release' );
+    }
+    return $self->parent( @rest );
 }
 
 1;

--- a/lib/Dist/Zilla/Path.pm
+++ b/lib/Dist/Zilla/Path.pm
@@ -6,7 +6,7 @@ package Dist::Zilla::Path;
 
 # ABSTRACT: Wrapper for Path::Tiny that provides backcompat and deprecation process for Path::Class
 
-use Path::Tiny qw();
+use Path::Tiny 0.052 qw();  # issue 427
 use Scalar::Util qw( blessed );
 use Sub::Exporter::Progressive -setup => {
     exports => [qw[ path  ]],

--- a/lib/Dist/Zilla/Plugin/DistINI.pm
+++ b/lib/Dist/Zilla/Plugin/DistINI.pm
@@ -67,7 +67,7 @@ sub gather_files {
   my $postlude = '';
 
   for (@{ $self->append_file }) {
-    my $fn = $self->zilla->root->file($_);
+    my $fn = $self->zilla->root->child($_);
 
     $postlude .= path($fn)->slurp_utf8;
   }

--- a/lib/Dist/Zilla/Plugin/DistINI.pm
+++ b/lib/Dist/Zilla/Plugin/DistINI.pm
@@ -7,7 +7,7 @@ with qw(Dist::Zilla::Role::FileGatherer);
 use Dist::Zilla::File::FromCode;
 
 use MooseX::Types::Moose qw(ArrayRef Str);
-use Path::Tiny;
+use Dist::Zilla::Path;
 
 use namespace::autoclean;
 

--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -2,7 +2,7 @@ package Dist::Zilla::Plugin::GatherDir;
 # ABSTRACT: gather all the files in a directory
 
 use Moose;
-use MooseX::Types::Path::Class qw(Dir File);
+use Dist::Zilla::Types::Path qw(Dir File);
 with 'Dist::Zilla::Role::FileGatherer';
 
 use namespace::autoclean;

--- a/lib/Dist/Zilla/Plugin/GatherDir/Template.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir/Template.pm
@@ -9,7 +9,7 @@ use namespace::autoclean;
 
 use autodie;
 use Dist::Zilla::File::FromCode;
-use Path::Tiny;
+use Dist::Zilla::Path;
 
 =head1 DESCRIPTION
 

--- a/lib/Dist/Zilla/Plugin/NextRelease.pm
+++ b/lib/Dist/Zilla/Plugin/NextRelease.pm
@@ -10,7 +10,7 @@ with (
   'Dist::Zilla::Role::AfterRelease',
 );
 
-use Path::Tiny;
+use Dist::Zilla::Path;
 use Moose::Util::TypeConstraints;
 use List::Util 'first';
 use String::Formatter 0.100680 stringf => {

--- a/lib/Dist/Zilla/Plugin/TemplateModule.pm
+++ b/lib/Dist/Zilla/Plugin/TemplateModule.pm
@@ -4,7 +4,7 @@ package Dist::Zilla::Plugin::TemplateModule;
 use Moose;
 with qw(Dist::Zilla::Role::ModuleMaker Dist::Zilla::Role::TextTemplate);
 
-use Path::Tiny;
+use Dist::Zilla::Path;
 
 use namespace::autoclean;
 

--- a/lib/Dist/Zilla/Plugin/TestRelease.pm
+++ b/lib/Dist/Zilla/Plugin/TestRelease.pm
@@ -24,16 +24,16 @@ This plugin was originally contributed by Christopher J. Madsen.
 =cut
 
 use File::pushd ();
-use Path::Class ();
+use Dist::Zilla::Path;
 
 sub before_release {
   my ($self, $tgz) = @_;
   $tgz = $tgz->absolute;
 
-  my $build_root = $self->zilla->root->subdir('.build');
+  my $build_root = $self->zilla->root->child('.build');
   $build_root->mkpath unless -d $build_root;
 
-  my $tmpdir = Path::Class::dir( File::Temp::tempdir(DIR => $build_root) );
+  my $tmpdir = path( File::Temp::tempdir(DIR => $build_root) );
 
   $self->log("Extracting $tgz to $tmpdir");
 
@@ -48,14 +48,14 @@ sub before_release {
     unless @files;
 
   # Run tests on the extracted tarball:
-  my $target = $tmpdir->subdir( $self->zilla->dist_basename );
+  my $target = $tmpdir->child( $self->zilla->dist_basename );
 
   local $ENV{RELEASE_TESTING} = 1;
   local $ENV{AUTHOR_TESTING} = 1;
   $self->zilla->run_tests_in($target);
 
   $self->log("all's well; removing $tmpdir");
-  $tmpdir->rmtree;
+  $tmpdir->remove_tree({ safe => 0 });
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Dist/Zilla/Prereqs.pm
+++ b/lib/Dist/Zilla/Prereqs.pm
@@ -5,7 +5,6 @@ use Moose;
 use MooseX::Types::Moose qw(Bool HashRef);
 
 use CPAN::Meta::Prereqs 2.120630; # add_string_requirement
-use Path::Class ();
 use String::RewritePrefix;
 use CPAN::Meta::Requirements 2.121; # requirements_for_module
 

--- a/lib/Dist/Zilla/Role/MintingProfile.pm
+++ b/lib/Dist/Zilla/Role/MintingProfile.pm
@@ -6,7 +6,6 @@ use Moose::Role;
 use namespace::autoclean;
 
 use File::ShareDir;
-use Path::Class;
 
 =head1 DESCRIPTION
 

--- a/lib/Dist/Zilla/Role/MintingProfile/ShareDir.pm
+++ b/lib/Dist/Zilla/Role/MintingProfile/ShareDir.pm
@@ -7,7 +7,7 @@ with 'Dist::Zilla::Role::MintingProfile';
 use namespace::autoclean;
 
 use File::ShareDir;
-use Path::Class;
+use Dist::Zilla::Path;
 
 =head1 DESCRIPTION
 
@@ -19,8 +19,8 @@ C<profile_dir> method that looks in the I<module>'s L<ShareDir|File::ShareDir>.
 sub profile_dir {
   my ($self, $profile_name) = @_;
 
-  my $profile_dir = dir( File::ShareDir::module_dir($self->meta->name) )
-                  ->subdir( $profile_name );
+  my $profile_dir = path( File::ShareDir::module_dir($self->meta->name) )
+                  ->child( $profile_name );
 
   return $profile_dir if -d $profile_dir;
 

--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -13,7 +13,7 @@ use Dist::Zilla::Chrome::Test;
 use File::pushd ();
 use File::Spec;
 use File::Temp;
-use Path::Tiny 0.052;
+use Dist::Zilla::Path;
 
 use Sub::Exporter::Util ();
 use Sub::Exporter -setup => {
@@ -86,7 +86,7 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
   sub slurp_file {
     my ($self, $filename) = @_;
 
-    Path::Tiny::path(
+    Dist::Zilla::Path::path(
       $self->tempdir->file($filename)
     )->slurp_utf8;
   }
@@ -94,7 +94,7 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
   sub slurp_file_raw {
     my ($self, $filename) = @_;
 
-    Path::Tiny::path(
+    Dist::Zilla::Path::path(
       $self->tempdir->file($filename)
     )->slurp_raw;
   }
@@ -151,7 +151,7 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
         my $unix_name = Path::Class::File->new_foreign("Unix", $name);
         my $fn = $tempdir->file($unix_name);
         $fn->dir->mkpath;
-        Path::Tiny::path($fn)->spew_utf8($content);
+        Dist::Zilla::Path::path($fn)->spew_utf8($content);
       }
     }
 

--- a/lib/Dist/Zilla/Types/Path.pm
+++ b/lib/Dist/Zilla/Types/Path.pm
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use utf8;
+
+package Dist::Zilla::Types::Path;
+
+# ABSTRACT: Workalike for MooseX::Types::Path::Class for Dist::Zilla::Path
+use namespace::autoclean;
+
+use MooseX::Types -declare => [qw( Dir File )];
+
+use MooseX::Types::Moose qw(Str ArrayRef);
+
+require Dist::Zilla::Path;
+
+# Because loading MX:Types:Path:Class
+# loads Path::Class itself and we want to avoid that so we can apply Devel::Hide
+# we avoid using MX:Types:Path:Class
+#
+# Also, we don't really need the Dir and File types from it,
+# only coercions for the respective classes ::Dir and ::File
+
+class_type('Dist::Zilla::Path');
+my $pc_dir = class_type('Path::Class::Dir');
+my $pc_file = class_type('Path::Class::File');
+
+class_type('Path::Tiny');
+subtype Dir,  as 'Dist::Zilla::Path';
+subtype File, as 'Dist::Zilla::Path';
+
+coerce 'Dist::Zilla::Path',
+  from Str,      via { Dist::Zilla::Path::path($_) },
+  from ArrayRef, via { Dist::Zilla::Path::path(@$_) },
+  from $pc_dir,   via { Dist::Zilla::Path::path($_) },
+  from $pc_file,  via { Dist::Zilla::Path::path($_) },
+  from 'Path::Tiny',        via { Dist::Zilla::Path::path($_) };
+
+coerce Dir,
+  from Str,      via { Dist::Zilla::Path::path($_) },
+  from ArrayRef, via { Dist::Zilla::Path::path(@$_) },
+  from $pc_dir,   via { Dist::Zilla::Path::path($_) },
+  from 'Path::Tiny',        via { Dist::Zilla::Path::path($_) };
+
+
+coerce File,
+  from Str,      via { Dist::Zilla::Path::path($_) },
+  from ArrayRef, via { Dist::Zilla::Path::path(@$_) },
+  from $pc_file,  via { Dist::Zilla::Path::path($_) },
+  from 'Path::Tiny',        via { Dist::Zilla::Path::path($_) };
+
+1;
+

--- a/lib/Dist/Zilla/Util.pm
+++ b/lib/Dist/Zilla/Util.pm
@@ -106,14 +106,14 @@ sub expand_config_package_name {
 }
 
 sub _global_config_root {
-  require Path::Class;
-  return Path::Class::dir($ENV{DZIL_GLOBAL_CONFIG_ROOT}) if $ENV{DZIL_GLOBAL_CONFIG_ROOT};
+  require Dist::Zilla::Path;
+  return Dist::Zilla::Path::path($ENV{DZIL_GLOBAL_CONFIG_ROOT}) if $ENV{DZIL_GLOBAL_CONFIG_ROOT};
 
   require File::HomeDir;
   my $homedir = File::HomeDir->my_home
     or Carp::croak("couldn't determine home directory");
 
-  return Path::Class::dir($homedir)->subdir('.dzil');
+  return Dist::Zilla::Path::path($homedir)->child('.dzil');
 }
 
 sub _assert_loaded_class_version_ok {

--- a/t/minter.t
+++ b/t/minter.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More 0.88;
 
 use File::pushd qw/pushd/;
-use Path::Class;
+use Dist::Zilla::Path;
 use Test::DZil;
 use Dist::Zilla::App::Tester;
 use YAML::Tiny;
@@ -38,9 +38,9 @@ like(
 );
 
 {
-  my $result = test_dzil( $tzil->tempdir->subdir('mint')->absolute, [qw(add Foo::Bar)] );
+  my $result = test_dzil( $tzil->tempdir->child('mint')->absolute, [qw(add Foo::Bar)] );
   ok(!$result->{exit_code}) || diag($result->{error});
-  my $pm = dir($result->{tempdir})->file('source/lib/Foo/Bar.pm')->slurp;
+  my $pm = path($result->{tempdir})->child('source/lib/Foo/Bar.pm')->slurp;
 
   like(
     $pm,

--- a/t/plugins/autoprereqs.t
+++ b/t/plugins/autoprereqs.t
@@ -11,7 +11,7 @@ sub build_meta {
 
   $tzil->build;
 
-  YAML::Tiny->new->read($tzil->tempdir->file('build/META.yml'))->[0];
+  YAML::Tiny->new->read($tzil->tempdir->child('build/META.yml'))->[0];
 }
 
 my $tzil = Builder->from_config(

--- a/t/plugins/filefinders.t
+++ b/t/plugins/filefinders.t
@@ -52,7 +52,7 @@ is_filelist(
   "GatherDir gathers all files in the source dir",
 );
 
-my $manifest = maniread($tzil->tempdir->file('build/MANIFEST')->stringify);
+my $manifest = maniread($tzil->tempdir->child('build/MANIFEST')->stringify);
 
 my $count = grep { exists $manifest->{$_} } @files;
 ok($count == @files, "all files found were in manifest");

--- a/t/plugins/gatherdir.t
+++ b/t/plugins/gatherdir.t
@@ -87,7 +87,7 @@ is_filelist(
   "GatherDir gathers all files in the source dir",
 );
 
-my $manifest = maniread($tzil->tempdir->file('build/MANIFEST')->stringify);
+my $manifest = maniread($tzil->tempdir->child('build/MANIFEST')->stringify);
 
 my $count = grep { exists $manifest->{$_} } @files;
 ok($count == @files, "all files found were in manifest");

--- a/t/plugins/manifest.t
+++ b/t/plugins/manifest.t
@@ -20,6 +20,7 @@ my $tzil = Builder->from_config(
       $^O =~ /^(MSWin32|cygwin)$/ ? () : (
         q{source/file\\with some\\whacks.txt} => "bar\n",
         q{source/file'with'quotes\\or\\backslash.txt} => "quux\n",
+        q{source/dir\\with some\\/whacks.txt} => "mar\n",
       ),
     },
   },
@@ -41,6 +42,7 @@ cmp_deeply(
     $^O =~ /^(MSWin32|cygwin)$/ ? () : (
       q{file\\with some\\whacks.txt},
       q{file'with'quotes\\or\\backslash.txt},
+      q{dir\\with some\\/whacks.txt},
     ),
   ),
   'manifest quotes files with spaces'
@@ -61,6 +63,7 @@ cmp_deeply(
     $^O =~ /^(MSWin32|cygwin)$/ ? () : (
       q{'file\\\\with some\\\\whacks.txt'},
       q{'file\\'with\\'quotes\\\\or\\\\backslash.txt'},
+      q{'dir\\\\with some\\\\/whacks.txt'},
     ),
   ),
   'manifest quotes files with spaces'

--- a/t/plugins/manifest.t
+++ b/t/plugins/manifest.t
@@ -27,7 +27,7 @@ my $tzil = Builder->from_config(
 
 $tzil->build;
 
-my $manihash = ExtUtils::Manifest::maniread($tzil->built_in->file('MANIFEST'));
+my $manihash = ExtUtils::Manifest::maniread($tzil->built_in->child('MANIFEST'));
 
 cmp_deeply(
   [ keys %$manihash ],

--- a/t/plugins/metanoindex.t
+++ b/t/plugins/metanoindex.t
@@ -34,7 +34,7 @@ my $tzil = Builder->from_config(
           MetaNoIndex => {
             file  => 'file-1.txt',
             files => 'file-2.txt',
-            
+
             dir         => 'dir-1',
             directory   => 'dir-2',
             directories => 'dir-3',

--- a/t/tester-demo.t
+++ b/t/tester-demo.t
@@ -37,7 +37,7 @@ ok(
 );
 
 use YAML::Tiny;
-my $yaml = YAML::Tiny->read($tester->built_in->file('META.yml'));
+my $yaml = YAML::Tiny->read($tester->built_in->child('META.yml'));
 my $meta = $yaml->[0];
 
 like($meta->{generated_by}, qr{Dist::Zilla}, "powered by... ROBOT DINOSAUR");

--- a/t/tester.t
+++ b/t/tester.t
@@ -23,7 +23,7 @@ is($tzil->VERSION, Dist::Zilla->VERSION, "zilla tester VERSION");
 my $basename = $tzil->dist_basename;
 my $tarball  = $tzil->archive_filename;
 
-$tarball = $tzil->built_in->parent->subdir('source')->file($tarball);
+$tarball = $tzil->built_in->parent->child('source')->child($tarball);
 $tarball = Archive::Tar->new($tarball->stringify);
 
 my $makefile_pl = File::Spec::Unix->catfile($basename, 'Makefile.PL');


### PR DESCRIPTION
I spent a bit of effort seeing if I could get this working.

Looks like I'm about 95% of the way there, just need a little buy-in from plugins. Though plugins _should_ work as-is due to the way I've done it, albeit with abundant superfluous warnings.

Test Suite passes tests with `PERL5OPT=-MDevel::Hide=Path::Class,Path::Class::File,Path::Class::Dir`.

Dzil also successfully builds with itself with the applied changes, and the only downside is copious lines of:

`file called on Dist::Zilla::Path. This is deprecated and will go away in a future release at /home/kent/perl5/perlbrew/perls/perl-5.19.8/lib/site_perl/5.19.8/Dist/Zilla/Plugin/PodWeaver.pm line 22`

Approach: I've made a somewhat self-propagating automatic dispatch thing. 

- Everything that asks for a Path::Tiny method calls a Path::Tiny method, but the result is always a Dist::Zilla::Path if Path::Tiny returns a Path::Tiny
- Everything that asks for a Path::Class::* method calls a Path::Class::* method, but the result is always a Dist::Zilla::Path if Path::Class returns a Path::Class

The only real place it will go wrong is where people have MooseX::Types that ask for Path::Class objects and don't have coercions set up. ( I couldn't remember if I was possible or how to set up coercions for things you don't control, and `coerce => 1` is impossible to set on code you don't own as well ).

So for that reason, I wouldn't roll this out *just yet*, but its already of a grade of usefulness that people like myself can use it to track down where they've got Path::Class dependent logic in the DZil plugins.

I'm amazed how productive I can be when I'm **supposed** to be packing and moving house ... which is why I'm not on IRC =)

#### Note

There's a few things I'm not 100% sure I got right, relative path handling is always tricky.
And in testing, I found I needed `remove_tree({ safe => 0 })` for some reason. I don't quite understand why. The documentation for that parameter in File::Path says `safe => 0` will simply not try removing files you don't have permissions to remove, so we really shouldn't need it .... however, without it, it doesn't want to delete directories due to not being empty:

```
t/plugins/testrelease.t ...... 
ok 1 - No failures occured building the release with TestRelease
Generating a Unix-style Makefile
Writing Makefile for DZT::Sample
Writing MYMETA.yml and MYMETA.json
cp lib/DZT/Sample.pm blib/lib/DZT/Sample.pm
PERL_DL_NONLAZY=1 /home/kent/perl5/perlbrew/perls/perl-5.19.8/bin/perl5.19.8 "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/basic.t .. ok
All tests successful.
Files=1, Tests=1,  0 wallclock secs ( 0.02 usr  0.00 sys +  0.02 cusr  0.00 csys =  0.04 CPU)
Result: PASS
cannot remove directory for /home/kent/perl/dist-zilla/tmp/vXQI9gmobg/source/.build/4a1ydD2ABX/DZT-Sample-0.001/blib/lib/DZT: Directory not empty at /home/kent/perl5/perlbrew/perls/perl-5.19.8/lib/site_perl/5.19.8/Path/Tiny.pm line 658.
cannot remove directory for /home/kent/perl/dist-zilla/tmp/vXQI9gmobg/source/.build/4a1ydD2ABX/DZT-Sample-0.001/blib/lib: Directory not empty at /home/kent/perl5/perlbrew/perls/perl-5.19.8/lib/site_perl/5.19.8/Path/Tiny.pm line 658.
cannot remove directory for /home/kent/perl/dist-zilla/tmp/vXQI9gmobg/source/.build/4a1ydD2ABX/DZT-Sample-0.001/blib: Directory not empty at /home/kent/perl5/perlbrew/perls/perl-5.19.8/lib/site_perl/5.19.8/Path/Tiny.pm line 658.
cannot remove directory for /home/kent/perl/dist-zilla/tmp/vXQI9gmobg/source/.build/4a1ydD2ABX/DZT-Sample-0.001: Directory not empty at /home/kent/perl5/perlbrew/perls/perl-5.19.8/lib/site_perl/5.19.8/Path/Tiny.pm line 658.
cannot remove directory for /home/kent/perl/dist-zilla/tmp/vXQI9gmobg/source/.build/4a1ydD2ABX: Directory not empty at /home/kent/perl5/perlbrew/perls/perl-5.19.8/lib/site_perl/5.19.8/Path/Tiny.pm line 658.
ok 2 - No failures occured in testing the release with TestRelease
# {
#   'root' => '/home/kent/perl/dist-zilla/tmp/vXQI9gmobg/source'
# }
ok 3 - Release happened
1..3
```

The docs:
```
        safe => $bool
            When set to a true value, will cause "remove_tree" to skip the
            files for which the process lacks the required privileges needed
            to delete files, such as delete privileges on VMS. In other words,
            the code will make no attempt to alter file permissions. Thus, if
            the process is interrupted, no filesystem object will be left in a
            more permissive mode.
```

/cc @karenetheridge 