### PR TITLE
FIX: ensure that ~/.dzil is never used when testing builds too

### DIFF
--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -134,6 +134,8 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
 
     local @INC = map {; ref($_) ? $_ : File::Spec->rel2abs($_) } @INC;
 
+    local $ENV{DZIL_GLOBAL_CONFIG_ROOT} = $tester_arg->{global_config_root};
+
     my $zilla = $self->$orig($arg);
 
     $zilla->_set_tempdir($tempdir);


### PR DESCRIPTION
..to reduce local changes in test behaviour, as came up in https://github.com/rjbs/Dist-Zilla/pull/276
