### PR TITLE
Zilla.pm and Builder.pm: Make distmeta fully dynamic and self-inject

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -485,13 +485,20 @@ hash; use a MetaProvider plugin instead.
 
 =cut
 
-has distmeta => (
-  is   => 'ro',
-  isa  => 'HashRef',
-  init_arg  => undef,
-  lazy      => 1,
+has _frozen_distmeta => (
+  is => ro =>,
+  lazy => 1,
+  predicate => '_has_frozen_distmeta',
   builder   => '_build_distmeta',
 );
+
+sub distmeta {
+  my ( $self ) = @_;
+  if ( $self->_has_frozen_distmeta ) {
+      return $self->_frozen_distmeta;
+  }
+  return $self->_build_distmeta;
+}
 
 sub _build_distmeta {
   my ($self) = @_;
@@ -523,6 +530,8 @@ sub _build_distmeta {
   for ($self->plugins_with(-MetaProvider)->flatten) {
     $meta = $meta_merge->merge($meta, $_->metadata);
   }
+
+  $meta->{prereqs} = $self->prereqs->as_string_hash;
 
   return $meta;
 }

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -326,9 +326,6 @@ sub build_in {
 
   $self->prereqs->finalize;
 
-  # Barf if someone has already set up a prereqs entry? -- rjbs, 2010-04-13
-  $self->distmeta->{prereqs} = $self->prereqs->as_string_hash;
-
   $_->setup_installer for @{ $self->plugins_with(-InstallTool) };
 
   $self->_check_dupe_files;


### PR DESCRIPTION
prereqs.

Looks kind crazy, but almost isn't.

Perks: Nobody can modify ->distmeta directly, don't even try.

Downsides: -MetaProvides stuff runs multiple times.

Though for some, this is a **perk**. The problem with metaprovides
being executed when the first instance of distmeta is called, is not
everything in dzil is entirely able to have its chips passed in by then.

Especially eschoteric tricks like trying to record metadata about the
munging of files themselves in MetaJSON.

An alternative approach may be to have a -MetaProvidesOnce role,
  and have a seperate key for that data.

Maybe -MetaProvidesOnceEarly or -MetaProvidesOnceLate to disambiguate
between things that are safe to run before munging, and those that need
munging to occur first.

I don't know, I'm tired and this code feels pretty crazy. But it might
be crazy enough to be useful.