### PR TITLE
link to metacpan.org instead of s.c.o for metaspec

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -499,7 +499,7 @@ sub _build_distmeta {
   my $meta = {
     'meta-spec' => {
       version => 2,
-      url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+      url     => 'https://metacpan.org/pod/CPAN::Meta::Spec',
     },
     name     => $self->name,
     version  => $self->version,

--- a/t/plugins/metaresources.t
+++ b/t/plugins/metaresources.t
@@ -73,7 +73,7 @@ my $generated_by_re = qr/\A\Q$generated_by\E(?:, \Q$converted_by\E)?\z/;
       generated_by   => re($generated_by_re),
       license        => [ 'perl_5' ],
       'meta-spec'    => {
-        url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+        url     => re(qr/^http.*CPAN::Meta::Spec$/),
         version => 2
       },
       name      => 'DZT-Sample',
@@ -150,7 +150,7 @@ my $generated_by_re = qr/\A\Q$generated_by\E(?:, \Q$converted_by\E)?\z/;
       generated_by   => re($generated_by_re),
       license        => [ 'perl_5' ],
       'meta-spec'    => {
-        url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+        url     => re(qr/^http.*CPAN::Meta::Spec$/),
         version => 2
       },
       name      => 'DZT-Sample',


### PR DESCRIPTION
tests loosened, to accomodate both s.c.o and metacpan in link after running through CPAN::Meta::Converter (see also https://github.com/Perl-Toolchain-Gang/CPAN-Meta/pull/47)