### PR TITLE
IMPROVEMENT: skip building manpages when using [MakeMaker] (for builds, not installs)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - the building of manpages is supressed in [MakeMaker]-driven builds
 
 5.020     2014-07-28 20:56:25-04:00 America/New_York
         - the default required version for ExtUtils::MakeMaker in [MakeMaker]

--- a/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
@@ -27,8 +27,8 @@ sub build {
   return
     if -e $makefile and (stat 'Makefile.PL')[9] <= (stat $makefile)[9];
 
-  system($^X => 'Makefile.PL') and die "error with Makefile.PL\n";
-  system($make)                and die "error running $make\n";
+  system($^X => qw(Makefile.PL INSTALLMAN1DIR=none INSTALLMAN3DIR=none)) and die "error with Makefile.PL\n";
+  system($make) and die "error running $make\n";
 
   return;
 }


### PR DESCRIPTION
I couldn't find an equivalent option for Module::Build -- but it doesn't look like they are generated for the 'test' command anyway.
