### PR TITLE
FIX: Amend [MetaTests] documentation to remove mention of Test::CPAN::Meta be...

### DIFF
--- a/lib/Dist/Zilla/Plugin/MetaTests.pm
+++ b/lib/Dist/Zilla/Plugin/MetaTests.pm
@@ -14,10 +14,8 @@ following files:
 
   xt/release/meta-yaml.t - a standard Test::CPAN::Meta test
 
-Note that this test doesn't actually do anything unless you have
-L<Test::CPAN::Meta> installed.
-
-L<Test::CPAN::Meta> will be added as a C<develop requires> dependency.
+L<Test::CPAN::Meta> will be added as a C<develop requires> dependency (which
+can be installed via C<< dzil listdeps --author | cpanm >>).
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
...ing optional

This test was changed in 878689147 to require Test::CPAN::Meta instead of
skipping the test when not installed.

This closes #295.
