### PR TITLE
Move file writing out of argument loop in dzil add

### DIFF
--- a/lib/Dist/Zilla/App/Command/add.pm
+++ b/lib/Dist/Zilla/App/Command/add.pm
@@ -67,9 +67,9 @@ sub execute {
   for my $name ( @$arg ) {
     my $factory = $minter->plugin_named(':DefaultModuleMaker');
     $factory->make_module({ name => $name });
-    for my $file ( @{ $factory->zilla->files} ) {
-      $zilla->_write_out_file($file, $root);
-    }
+  }
+  for my $file ( @{ $factory->zilla->files} ) {
+    $zilla->_write_out_file($file, $root);
   }
 }
 


### PR DESCRIPTION
Previously, on a second entry the file generated in the first would be written again, which resulted in an error. Now it is written after all files have been generated.
