### PR TITLE
[Manifest] builds contents as bytes

### DIFF
--- a/lib/Dist/Zilla/Plugin/Manifest.pm
+++ b/lib/Dist/Zilla/Plugin/Manifest.pm
@@ -43,6 +43,7 @@ sub gather_files {
 
   my $file = Dist::Zilla::File::FromCode->new({
     name => 'MANIFEST',
+    code_return_type => 'bytes',
     code => sub {
       my $generated_by = sprintf "%s v%s", ref($self), $self->VERSION || '(dev)';
 


### PR DESCRIPTION
The [Manifest] plugin builds content for the MANIFEST file from code, but doesn't declare that that code returns bytes, rather than characters. This means that if you have "interesting" files in your dist (which may or may not be a bad idea) then you'll get warnings about missing files:

```
WARNING: the following files are missing in your kit:
    corpus/ã¿ãã¡ãã
```

because the manifest check is expecting the garbage filename, but your dist actually includes the file with the correct filename. No file is missing, but MANIFEST is wrong.

This simply adds the appropriate declaration when creating the MANIFEST file.
