### PR TITLE
IMPROVEMENT: skip doing a new build if a build has already been done

### DIFF
--- a/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker/Runner.pm
@@ -20,6 +20,8 @@ has 'make_path' => (
 sub build {
   my $self = shift;
 
+  return if -d 'blib';
+
   my $make = $self->make_path;
   system($^X => 'Makefile.PL') and die "error with Makefile.PL\n";
   system($make)                and die "error running $make\n";

--- a/lib/Dist/Zilla/Role/BuildPL.pm
+++ b/lib/Dist/Zilla/Role/BuildPL.pm
@@ -23,6 +23,8 @@ and L<Dist::Zilla::Plugin::InstallTool> roles yourself.
 sub build {
   my $self = shift;
 
+  return if -d 'blib';
+
   system $^X, 'Build.PL' and die "error with Build.PL\n";
   system $^X, 'Build'    and die "error running $^X Build\n";
 


### PR DESCRIPTION
I noticed in the docs of [RunExtraTests]:

`"If C<RunExtraTests> is listed after one of the normal test-running
plugins (e.g. C<MakeMaker> or C<ModuleBuild>), then the dist will not
be rebuilt between running the normal tests and the extra tests."`

and I thought "no, it cannot be so!" -- but indeed, RunExtraTests's 'build' sub checks for -d blib, but [MakeMaker::TestRunner] does not, so if it comes after, it does another build!

I thought about comparing the mtime of Makefile.PL to Build.PL, but TestRunners are invoked only after a build has completed, so I can't think of any non-crazy case where the file would get modified and we'd want to re-run it.
