### PR TITLE
Command 'add': load Path::Class and File::pushd only on 'execute'

### DIFF
--- a/lib/Dist/Zilla/App/Command/add.pm
+++ b/lib/Dist/Zilla/App/Command/add.pm
@@ -4,8 +4,6 @@ package Dist::Zilla::App::Command::add;
 # ABSTRACT: add a module to a dist
 
 use Dist::Zilla::App -command;
-use Path::Class;
-use File::pushd ();
 
 =head1 SYNOPSIS
 
@@ -51,6 +49,9 @@ sub execute {
   my $zilla = $self->zilla;
   my $dist = $zilla->name;
 
+  require Path::Class;
+  require File::pushd;
+
   require Dist::Zilla::Dist::Minter;
   my $minter = Dist::Zilla::Dist::Minter->_new_from_profile(
     [ $opt->provider, $opt->profile ],
@@ -61,7 +62,7 @@ sub execute {
     },
   );
 
-  my $root = dir($zilla->root)->absolute;
+  my $root = Path::Class::dir($zilla->root)->absolute;
   my $wd = File::pushd::pushd($minter->root);
 
   my $factory = $minter->plugin_named(':DefaultModuleMaker');


### PR DESCRIPTION
... because every Command plugin is loaded even if not called, so plugins must use lazy loading.
