### PR TITLE
FIX: better error when file is unexpectedly missing

### DIFF
--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -171,9 +171,11 @@ sub gather_files {
 sub _file_from_filename {
   my ($self, $filename) = @_;
 
+  my @stat = stat $filename or $self->log_fatal("$filename does not exist!");
+
   return Dist::Zilla::File::OnDisk->new({
     name => $filename,
-    mode => (stat $filename)[2] & 0755, # kill world-writeability
+    mode => $stat[2] & 0755, # kill world-writeability
   });
 }
 

--- a/lib/Dist/Zilla/Plugin/GatherDir/Template.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir/Template.pm
@@ -32,9 +32,11 @@ sub _file_from_filename {
 
   my $template = path($filename)->slurp_utf8;
 
+  my @stat = stat $filename or $self->log_fatal("$filename does not exist!");
+
   return Dist::Zilla::File::FromCode->new({
     name => $filename,
-    mode => ((stat $filename)[2] & 0755) | 0200, # kill world-writeability, make sure owner-writable.
+    mode => ($stat[2] & 0755) | 0200, # kill world-writeability, make sure owner-writable.
     code => sub {
       my ($file_obj) = @_;
       $self->fill_in_string(


### PR DESCRIPTION
This can happen when the gathering logic is different from "everything I see
in the filesystem", e.g. in [Git::GatherDir] which gathers everything known to
git, and the file isn't actually there.  Without this check, the user sees:

Use of uninitialized value in bitwise and (&) at .../Dist/Zilla/Plugin/GatherDir.pm line 175.

..which doesn't tell the user exactly what went wrong.
