### PR TITLE
IMPROVEMENT: "dzil authordeps" now properly understands "; authordep perl = <version>"

### DIFF
--- a/corpus/dist/AutoPrereqs/dist.ini
+++ b/corpus/dist/AutoPrereqs/dist.ini
@@ -5,6 +5,8 @@ license = Perl_5
 copyright_holder = foobar
 copyright_year   = 2009
 
+; authordep perl = 5.005
+
 [GatherDir]
 [ExecDir]
 [AutoPrereqs]

--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -101,7 +101,13 @@ sub extract_author_deps {
 
   my @final =
     map { { $_ => $vermap->{$_} } }
-    grep { $missing ? (! Class::Load::try_load_class($_, ($vermap->{$_} ? {-version => $vermap->{$_}} : ()))) : 1 }
+    grep {
+      $missing
+        ? $_ eq 'perl'
+          ? ($vermap->{perl} ? !eval "use $vermap->{perl}; 1" : ())
+          : (! Class::Load::try_load_class($_, ($vermap->{$_} ? {-version => $vermap->{$_}} : ())))
+        : 1
+      }
     List::MoreUtils::uniq
     @packages;
 

--- a/t/commands/authordeps.t
+++ b/t/commands/authordeps.t
@@ -17,7 +17,10 @@ my $authordeps =
 
 is_deeply(
     $authordeps,
-    [ map { +{"Dist::Zilla::Plugin::$_" => 0} } qw<AutoPrereqs Encoding ExecDir GatherDir MetaYAML> ],
+    [
+      +{ perl => '5.005' },
+      map { +{"Dist::Zilla::Plugin::$_" => 0} } qw<AutoPrereqs Encoding ExecDir GatherDir MetaYAML>,
+    ],
     "authordeps in corpus/dist/AutoPrereqs"
 ) or diag explain $authordeps;
 


### PR DESCRIPTION
I had a dist with an ; authordep perl = 5.014 and noticed that this wasn't making its way into develop prereqs (via [Prereqs::AuthorDeps]) and so nothing was verifying that this prereq was satisfied. :o
