### PR TITLE
default dzil install to cpan instead of cpanm

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
         - NextRelease now bases the new file on disk on the original file on
           disk, skipping any munging that happened in between
+        - default dzil install to use cpan instead of cpanm for higher
+          portability
 
 5.032     2015-02-21 09:36:00-05:00 America/New_York
         - when :version is in plugin config, it's now enforced as soon as it's

--- a/lib/Dist/Zilla/App/Command/install.pm
+++ b/lib/Dist/Zilla/App/Command/install.pm
@@ -22,7 +22,7 @@ sub abstract { 'install your dist' }
 =cut
 
 sub opt_spec {
-  [ 'install-command=s', 'command to run to install (e.g. "cpan .")' ],
+  [ 'install-command=s', 'command to run to install (e.g. "cpanm .")' ],
   [ 'keep-build-dir|keep' => 'keep the build directory even after a success' ],
 }
 
@@ -36,7 +36,7 @@ Any value that works with L<C<system>|perlfunc/system> is accepted.
 
 If not specified, calls (roughly):
 
-    cpanm .
+    cpan .
 
 For more information, look at the L<install|Dist::Zilla::Dist::Builder/install> method in
 Dist::Zilla.

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -657,7 +657,7 @@ sub install {
     my $wd = File::pushd::pushd($target);
     my @cmd = $arg->{install_command}
             ? @{ $arg->{install_command} }
-            : (cpanm => ".");
+            : (cpan => ".");
 
     $self->log_debug([ 'installing via %s', \@cmd ]);
     system(@cmd) && $self->log_fatal([ "error running %s", \@cmd ]);


### PR DESCRIPTION
As of 1.7001 (Sep 08, 2013) cpanm is broken in at least these known ways on
MSWin32:

- a bug that forces system owners to perform many deletion steps when cleaning up .build manually: https://github.com/miyagawa/cpanminus/issues/370
- one bug unrelated to dzil (has to do with carton)
- a bug that causes build.log to replicate and fill up the hdd: https://github.com/miyagawa/cpanminus/pull/368

Despite the latter issue being quite urgent and a fix having been merged, miyagawa doesn't seem to show inclination to actually do a release anytime soon and hasn't communicated any intent to do one despite being asked to.

As such i consider cpanm to be unsuitable for default use by Dist::Zilla.