### PR TITLE
skip passing empty hashrefs, arrayrefs to WriteMakefileArgs

### DIFF
--- a/lib/Dist/Zilla/Plugin/MakeMaker.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker.pm
@@ -210,8 +210,8 @@ sub write_makefile_args {
     EXE_FILES => [ @exe_files ],
 
     CONFIGURE_REQUIRES => $prereqs_dump->(qw(configure requires)),
-    BUILD_REQUIRES     => $build_prereq,
-    TEST_REQUIRES      => $test_prereq,
+    keys %$build_prereq ? ( BUILD_REQUIRES => $build_prereq ) : (),
+    keys %$test_prereq ? ( TEST_REQUIRES => $test_prereq ) : (),
     PREREQ_PM          => $prereqs_dump->(qw(runtime   requires)),
 
     test => { TESTS => join q{ }, sort keys %test_dirs },


### PR DESCRIPTION
This was resulting in ugly prereqs in META.json like:

```
"prereqs" : {
   "build" : {
      "requires" : {}
   },
   "test" : {
      "requires" : {}
   },
   ...
},
```
