### PR TITLE
Minor tweaks to Path Handling interfaces to avoid forcing end users to use Path::Class directly

### DIFF
--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -272,10 +272,12 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
 
     local @INC = map {; ref($_) ? $_ : File::Spec->rel2abs($_) } @INC;
 
-    local $ENV{DZIL_GLOBAL_CONFIG_ROOT} = $tester_arg->{global_config_root};
+    my $global_config_root = Path::Class::dir($tester_arg->{global_config_root})->absolute;
+
+    local $ENV{DZIL_GLOBAL_CONFIG_ROOT} = $global_config_root;
 
     my $global_stashes = $self->_setup_global_config(
-      $tester_arg->{global_config_root},
+      $global_config_root,
       { chrome => $arg->{chrome} },
     );
 

--- a/t/commands/authordeps.t
+++ b/t/commands/authordeps.t
@@ -5,11 +5,10 @@ use Test::More 0.88 tests => 1;
 use autodie;
 
 use Dist::Zilla::Util::AuthorDeps;
-use Path::Class;
 
 my $authordeps =
     Dist::Zilla::Util::AuthorDeps::extract_author_deps(
-	dir('corpus/dist/AuthorDeps'),
+	'corpus/dist/AuthorDeps',
 	0
     );
 

--- a/t/minter.t
+++ b/t/minter.t
@@ -16,7 +16,7 @@ use Test::File::ShareDir -share => {
 my $tzil = Minter->_new_from_profile(
   [ Default => 'default' ],
   { name => 'DZT-Minty', },
-  { global_config_root => dir('corpus/global')->absolute },
+  { global_config_root => 'corpus/global' },
 );
 
 $tzil->mint_dist;


### PR DESCRIPTION
Attached are some minor tweaks to force Path coercion to Path::Class objects instead of demanding end users to use Path::Class.

- Allows Plugin authors to pass bare strings
- Allows Plugin authors to pass Path::Tiny objects.

These changes should have no impact on *internal* interaction and only make the API more resilient, and help smooth eventual transition to Path::Tiny by allowing more Plugins to use it **now**

/cc @karenetheridge 