### PR TITLE
FIX: incorrect "added_by" in file objects (github#284)

### DIFF
--- a/lib/Dist/Zilla/File/FromCode.pm
+++ b/lib/Dist/Zilla/File/FromCode.pm
@@ -96,9 +96,9 @@ sub encoded_content {
   }
 }
 
-around 'added_by' => sub {
-  my ($orig, $self) = @_;
-  return sprintf("%s from coderef set by %s", $self->code_return_type, $self->$orig);
+sub _set_added_by {
+  my ($self, $value) = @_;
+  return $self->_push_added_by(sprintf("%s from coderef added by %s", $self->code_return_type, $value));
 };
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Dist/Zilla/Role/MutableFile.pm
+++ b/lib/Dist/Zilla/Role/MutableFile.pm
@@ -55,8 +55,9 @@ sub content {
     }
   }
   else {
-    my ($pkg, undef, $line) = caller;
-    $self->_update_by('content', sprintf( "%s line %s", $pkg, $line));
+    my ($pkg, $line) = $self->_caller_of('content');
+    $self->_content_source('content');
+    $self->_push_added_by(sprintf("content set by %s (%s line %s)", $self->_caller_plugin_name, $pkg, $line));
     $self->clear_encoded_content;
     return $self->_content(@_);
   }
@@ -87,8 +88,9 @@ sub encoded_content {
       return $self->_encoded_content($self->_encode($self->content));
     }
   }
-  my ($pkg, undef, $line) = caller;
-  $self->_update_by('encoded_content', sprintf( "%s line %s", $pkg, $line));
+  my ($pkg, $line) = $self->_caller_of('encoded_content');
+  $self->_content_source('encoded_content');
+  $self->_push_added_by(sprintf("encoded_content set by %s (%s line %s)", $self->_caller_plugin_name, $pkg, $line));
   $self->clear_content;
   $self->_encoded_content(@_);
 }
@@ -100,15 +102,9 @@ has _content_source => (
     builder => '_build_content_source',
 );
 
-sub _update_by {
-  my ($self, $attr, $from) = @_;
-  $self->_content_source($attr);
-  $self->_set_added_by($from);
-}
-
-around 'added_by' => sub {
-  my ($orig, $self) = @_;
-  return sprintf("%s set by %s", $self->_content_source, $self->$orig);
+sub _set_added_by {
+  my ($self, $value) = @_;
+  return $self->_push_added_by(sprintf("%s added by %s", $self->_content_source, $value));
 };
 
 # we really only need one of these and only if _content or _encoded_content

--- a/t/file-addedby.t
+++ b/t/file-addedby.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings FATAL => 'all';
+
+use Test::More;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
+use Test::DZil;
+use Test::Deep;
+use Test::Fatal;
+use Path::Tiny;
+use List::Util 'first';
+
+my $tzil = Builder->from_config(
+    { dist_root => 't/does_not_exist' },
+    {
+        add_files => {
+            path(qw(source dist.ini)) => simple_ini(
+                'GatherDir',                                    # a file gatherer (adds OnDisk file)
+                'PodSyntaxTests',                               # a file gatherer (adds InMemory file)
+                'Manifest',                                     # a file gatherer (adds FromCode file)
+                [ PkgVersion => { finder => ':AllFiles' } ],    # a file munger that changes content
+                'ExtraTests',                                   # a file munger that changes filename
+            ),
+            path(qw(source lib DZT Sample.pm)) => "package DZT::Sample;\n\n1",
+        },
+    },
+);
+
+$tzil->chrome->logger->set_debug(1);
+is(
+    exception { $tzil->build },
+    undef,
+    'build proceeds normally',
+) or diag 'saw log messages: ', explain $tzil->log_messages;
+
+my $module = first { $_->name eq path(qw(lib DZT Sample.pm)) } @{ $tzil->files };
+cmp_deeply(
+    $module,
+    methods(
+        added_by => all(
+            re(qr/\bencoded_content added by GatherDir \(Dist::Zilla::Plugin::GatherDir line \d+\)(;|$)/),
+            re(qr/\bencoded_content set by PkgVersion \(Dist::Zilla::Role::PPI line \d+\)(;|$)/),
+        ),
+    ),
+    'OnDisk file added by GatherDir, set by PkgVersion has correct properties',
+);
+
+my $test = first { $_->name eq path(qw(t release-pod-syntax.t)) } @{ $tzil->files };
+cmp_deeply(
+    $test,
+    methods(
+        added_by => all(
+            re(qr/^content added by PodSyntaxTests \(Dist::Zilla::Plugin::InlineFiles line \d+\)(;|$)/),
+            re(qr/\bcontent set by ExtraTests \(Dist::Zilla::Plugin::ExtraTests line \d+\)(;|$)/),
+            re(qr/\bfilename set by ExtraTests \(Dist::Zilla::Plugin::ExtraTests line \d+\)(;|$)/),
+        ),
+    ),
+    'InMemory file altered by all of PodSyntaxTests, PkgVersion and ExtraTests has correct properties',
+);
+
+my $manifest = first { $_->name eq path('MANIFEST') } @{ $tzil->files };
+cmp_deeply(
+    $manifest,
+    methods(
+        added_by => re(qr/^bytes from coderef added by Manifest \(Dist::Zilla::Plugin::Manifest line \d+\)$/),
+    ),
+    'FromCode file added by Manifest has correct properties',
+);
+
+done_testing;


### PR DESCRIPTION
calculate 'added_by' string immediately, on object creation, and add
additional information to this attribute to track change information.

This gets us out of the inconsistencies created in the 5.000 refactoring of file objects.
Closes #284.
