### PR TITLE
FIX: avoid $VERSION assignments in comments that are hiding in PPI::Statement nodes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - [PkgVersion] now properly skips over $VERSION assignments in
+          comments (Karen Etheridge, github #322)
 
 5.019     2014-05-20 21:11:47-04:00 America/New_York
         - remove a very brief-lived attempt to double-decode

--- a/lib/Dist/Zilla/Role/PPI.pm
+++ b/lib/Dist/Zilla/Role/PPI.pm
@@ -80,7 +80,7 @@ sub document_assigns_to_variable {
 
   # Clone because ppi_document_for_file which the caller is likely to
   # have retrieved his document from caches aggressively, and we'd
-  # like to prun POD and comments.
+  # like to prune POD and comments.
   #
   # It would be pretty stupid of us to say we found a variable in some
   # comment or in the POD, which we might do because if the POD is
@@ -93,7 +93,7 @@ sub document_assigns_to_variable {
 
   my $finder = sub {
     my $node = $_[1];
-    return 1 if $node->isa('PPI::Statement') && $node->content =~ /(?<!\\)\Q$variable\E\s*=/sm;
+    return 1 if $node->isa('PPI::Statement') && $node->content =~ /^[^#]*(?<!\\)\Q$variable\E\s*=/sm;
     return 0;
   };
 

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -32,6 +32,14 @@ package DZT::WInComment;
 1;
 ';
 
+my $in_comment_in_sub = '
+package DZT::WInCommentInSub;
+sub foo {
+    # our $VERSION = 1.234;
+}
+1;
+';
+
 my $in_pod_stm = '
 package DZT::WInPODStm;
 
@@ -118,6 +126,7 @@ my $tzil = Builder->from_config(
       'source/lib/DZT/WVerTwoLines.pm' => $with_version_two_lines,
       'source/lib/DZT/WStrEscaped.pm'  => $in_a_string_escaped,
       'source/lib/DZT/WInComment.pm' => $in_comment,
+      'source/lib/DZT/WInCommentInSub.pm' => $in_comment_in_sub,
       'source/lib/DZT/WInPODStm.pm' => $in_pod_stm,
       'source/lib/DZT/R1.pm'     => $repeated_packages,
       'source/lib/DZT/Monkey.pm' => $monkey_patched,
@@ -173,6 +182,13 @@ like(
   $dzt_wver_in_comment,
   qr{^\s*\$\QDZT::WInComment::VERSION = '0.001';\E\s*$}m,
   "added to DZT::WInComment; the one we have is in a comment",
+);
+
+my $dzt_wver_in_comment_in_sub = $tzil->slurp_file('build/lib/DZT/WInCommentInSub.pm');
+like(
+  $dzt_wver_in_comment_in_sub,
+  qr{^\s*\$\QDZT::WInCommentInSub::VERSION = '0.001';\E\s*$}m,
+  "added to DZT::WInCommentInSub; the one we have is in a comment",
 );
 
 my $dzt_wver_in_pod_stm = $tzil->slurp_file('build/lib/DZT/WInPODStm.pm');


### PR DESCRIPTION
For example, any comment inside a sub will have the comment's contents show up
in the PPI::Statement's content string, such as in Module::Metadata version
1.000022 line 668.
