### PR TITLE
FIX: minimum required version of Module::Build

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for {{$dist->name}}
         - the default required version for ExtUtils::MakeMaker in [MakeMaker]
           has been removed
         - load DateTime lazily
+        - the default required version for Module::Build in [ModuleBuild] has
+          been lowered
 
 5.019     2014-05-20 21:11:47-04:00 America/New_York
         - remove a very brief-lived attempt to double-decode

--- a/lib/Dist/Zilla/Plugin/ModuleBuild.pm
+++ b/lib/Dist/Zilla/Plugin/ModuleBuild.pm
@@ -26,7 +26,7 @@ L<Module::Build>.
 
 B<Optional:> Specify the minimum version of L<Module::Build> to depend on.
 
-Defaults to 0.3601
+Defaults to 0.3601 if a sharedir is being used, otherwise 0.28.
 
 =attr mb_class
 
@@ -45,7 +45,11 @@ mb_class. Defaults to C<inc>.
 has 'mb_version' => (
   isa => 'Str',
   is  => 'rw',
-  default => '0.3601',
+  lazy => 1,
+  default => sub {
+    my $self = shift;
+    keys %{$self->zilla->_share_dir_map} ? '0.3601' : '0.28';
+  },
 );
 
 has 'mb_class' => (

--- a/t/plugins/modulebuild.t
+++ b/t/plugins/modulebuild.t
@@ -43,13 +43,13 @@ use Test::DZil;
     },
     build_requires => {
       'Builder::Bob'  => '9.901',
-      'Module::Build' => '0.3601',
+      'Module::Build' => '0.28',
     },
     test_requires => {
       'Test::Deet'    => '7',
     },
     'configure_requires' => {
-      'Module::Build' => '0.3601',
+      'Module::Build' => '0.28',
     },
   );
 


### PR DESCRIPTION
Module::Build only needs to be at version 0.28 usually; 0.3601 is only needed for sharedirs.  This results in fewer needless upgrades in the range of [5.9.4, 5.11.3].
