### PR TITLE
warn the user about an old [MakeMaker::Awesome]

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -55,3 +55,4 @@ remove = Some::Package::That::Does::Not::Exist::Due::To::A::Typo
 Dist::Zilla::Plugin::MakeMaker::Awesome = < 0.22
 
 [Test::CheckBreaks]
+conflicts_module = Moose::Conflicts


### PR DESCRIPTION
Dist::Zilla 5.020 broke [MakeMaker::Awesome] ($eumm_version became undef); version 0.22 fixes that.  These changes add x_breaks metadata, and a t/zzz-check-breaks.t that checks that data, as well as looking at the conflict information prepared by Moose::Conflicts.  This test never fails; it only diag()s noisily when it finds something.
