### PR TITLE
On a locale-less system, skip encoding/decoding prompts

### DIFF
--- a/lib/Dist/Zilla/Chrome/Term.pm
+++ b/lib/Dist/Zilla/Chrome/Term.pm
@@ -25,9 +25,12 @@ has logger => (
 
 sub _build_logger {
   my $self = shift;
-  my $layer = sprintf(":encoding(%s)", $self->term_enc);
-  binmode( STDOUT, $layer );
-  binmode( STDERR, $layer );
+  my $enc = $self->term_enc;
+  if ( $enc ) {
+    my $layer = sprintf(":encoding(%s)", $enc);
+    binmode( STDOUT, $layer );
+    binmode( STDERR, $layer );
+  }
   return Log::Dispatchouli->new({
       ident     => 'Dist::Zilla',
       to_stdout => 1,


### PR DESCRIPTION
This primarily affects Android, but I assume it can be reproduced on any system if you unset LC_ALL and all the other locale-related variables.
