### PR TITLE
Fix implicit CR/LF layer on Win32 messing up tell(). Closes #289

### DIFF
--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -29,7 +29,7 @@ sub extract_author_deps {
     unless -e $ini;
 
   my $fh = $ini->openr;
-  binmode($fh, ":encoding(UTF-8)");
+  binmode($fh, ":raw:encoding(UTF-8)");
 
   require Config::INI::Reader;
   my $config = Config::INI::Reader->read_handle($fh);


### PR DESCRIPTION
Attempted fix at #289. 

@wchristian , if you get time, would you be able to confirm this patch fixes Win32's test suite?
