### PR TITLE
Fix situation where ABSTRACT comment is empty

### DIFF
--- a/lib/Dist/Zilla/Util.pm
+++ b/lib/Dist/Zilla/Util.pm
@@ -24,7 +24,7 @@ use String::RewritePrefix 0.002; # better string context behavior
     my ($self, $event) = @_;
     return if $self->{abstract};
     return $self->{abstract} = $1
-      if $event->{content}=~ /^\s*#+\s*ABSTRACT:\s*(.+)$/m;
+      if $event->{content}=~ /^\s*#+\s*ABSTRACT:\s*(\S.*)$/m;
     return;
   }
   sub handle_event {


### PR DESCRIPTION
Hi Rik,

If you have the following line:

```
# ABSTRACT:
```

Then you get the next line of code as the abstract. I think the intention of the code was to not match at this point, so the abstract would be extracted from the pod. This change does that.

Possibly it should warn if the above case if found, "You doofus, you've got a blank ABSTRACT".

Sorry I didn't add a test - I'm supposed to be playing with the kids, which I will be once I create this pull request. Oh and do a release to fix my dist :-)

Cheers,
Neil

Edit: um, I appear to have put MANIFEST in the commit message. I mean ABSTRACT of course!
