### PR TITLE
omit the trailing space in the "use" line when eumm_version defaults to undef

### DIFF
--- a/lib/Dist/Zilla/Plugin/MakeMaker.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker.pm
@@ -85,7 +85,7 @@ use warnings;
 
 {{ $perl_prereq ? qq[use $perl_prereq;] : ''; }}
 
-use ExtUtils::MakeMaker {{ defined $eumm_version ? $eumm_version : '' }};
+use ExtUtils::MakeMaker{{ defined $eumm_version ? ' ' . $eumm_version : '' }};
 
 {{ $share_dir_code{preamble} || '' }}
 


### PR DESCRIPTION
Because extra whitespace just looks icky!
