### PR TITLE
remove special case for main_module in :InstallModules

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -64,7 +64,6 @@ sub _setup_default_plugins {
         my ($file, $self) = @_;
         local $_ = $file->name;
         return 1 if m{\Alib/} and m{\.(pm|pod)$};
-        return 1 if $_ eq $self->zilla->main_module;
         return;
       },
     });


### PR DESCRIPTION
The main_module builder sub only looks in lib/, and this line never worked
anyway (it was trying to match a file object against a filename)
