### PR TITLE
Fix situation where ABSTRACT comment is empty

### DIFF
--- a/corpus/dist/DZ3/dist.pl
+++ b/corpus/dist/DZ3/dist.pl
@@ -1,0 +1,8 @@
+name    => 'DZ3',
+version => '0.001',
+author  => 'E. Xavier Ample <example@example.org>',
+license => 'Perl_5',
+copyright_holder => 'E. Xavier Ample',
+[
+  '@Classic',
+]

--- a/corpus/dist/DZ3/lib/DZ3.pm
+++ b/corpus/dist/DZ3/lib/DZ3.pm
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+package DZ3;
+
+# ABSTRACT:
+
+sub main {
+  return 1;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+DZ3 - a sample module for testing handling of empty ABSTRACT comment
+
+=head1 HEY, MAINTAINER
+
+Note that we have C<< =head1 NAME >> here, and an empty ABSTRACT comment.
+
+The empty ABSTRACT comment should be skipped, and the NAME one used.
+
+=cut

--- a/lib/Dist/Zilla/Util.pm
+++ b/lib/Dist/Zilla/Util.pm
@@ -24,7 +24,7 @@ use String::RewritePrefix 0.002; # better string context behavior
     my ($self, $event) = @_;
     return if $self->{abstract};
     return $self->{abstract} = $1
-      if $event->{content}=~ /^\s*#+\s*ABSTRACT:\s*(.+)$/m;
+      if $event->{content}=~ /^\s*#+\s*ABSTRACT:[ \t]*(\S.*)$/m;
     return;
   }
   sub handle_event {

--- a/t/empty-abstract.t
+++ b/t/empty-abstract.t
@@ -1,0 +1,17 @@
+#! perl
+
+use strict;
+use warnings;
+use Dist::Zilla::Util;
+use Dist::Zilla::File::OnDisk;
+use Test::More 0.88;
+
+my $file = Dist::Zilla::File::OnDisk->new({name => 'corpus/dist/DZ3/lib/DZ3.pm'})
+            || BAIL_OUT("can't find DZ3.pm");
+
+my $expected = 'a sample module for testing handling of empty ABSTRACT comment';
+my $abstract = Dist::Zilla::Util->abstract_from_file($file);
+
+is($abstract, $expected, "We should see the abstract from the =head NAME section in pod");
+
+done_testing();


### PR DESCRIPTION
Bizarrely, my first thought on waking up this morning was "Jeez, that \S+ was a boneheaded regexp".

So here's an improved change:
- Added testcase for the problem situation (blank ABSTRACT comment, expect to take abstract from NAME)
- Regexp that works for abstracts that have more than one word :-)
- All tests pass

If you have the following line:
    # ABSTRACT:
Then you currently get the next line (following the ABSTRACT comment)
as the abstract.
I think the intention of the code was to not match at this point,
so the abstract would be extracted from the pod

The regexp is now:

```
/^\s*#+\s*ABSTRACT:[ \t]*(\S.*)$/m
```

Need to have the `[ \t]`, rather than

```
ABSTRACT:\s*
```

Because the \s\* was slurping up the newline, causing the rest of the previous
regexp to grab the following line. I'm also assuming that DZ expects a single
line abstract comment, and isn't expected to support:

```
# ABSTRACT: this is the start of a really long abstract
#           that runs across multiple lines
```

Added a testcase, which failed without the change, and passes with the change.
The rest of the testsuite still passes, which is an improvement on my
previous pull request :-)

I'm not at all familiar with the internals of DZ, so suspect that I didn't
write the test in "the right way", but it works.
