### PR TITLE
Add --exe flag to authordeps

### DIFF
--- a/lib/Dist/Zilla/App/Command/authordeps.pm
+++ b/lib/Dist/Zilla/App/Command/authordeps.pm
@@ -25,6 +25,7 @@ sub opt_spec {
     [ 'root=s' => 'the root of the dist; defaults to .' ],
     [ 'missing' => 'list only the missing dependencies' ],
     [ 'versions' => 'include required version numbers in listing' ],
+    [ 'exe=s' => 'command to be used to install dependencies. (e.g. cpanm)' ],
   );
 }
 
@@ -34,12 +35,20 @@ sub execute {
   require Path::Class;
   require Dist::Zilla::Util::AuthorDeps;
 
+  my $reqs = Dist::Zilla::Util::AuthorDeps::extract_author_deps(
+    Path::Class::dir(defined $opt->root ? $opt->root : '.'),
+    $opt->missing,
+  );
+
+  if ($opt->exe) {
+    Dist::Zilla::Util::AuthorDeps::install_author_deps(
+      $reqs, $opt->exe
+    );
+  }
+
   my $deps =
     Dist::Zilla::Util::AuthorDeps::format_author_deps(
-      Dist::Zilla::Util::AuthorDeps::extract_author_deps(
-        Path::Class::dir(defined $opt->root ? $opt->root : '.'),
-        $opt->missing,
-      ), $opt->versions
+      $reqs, $opt->versions
     );
   $self->log($deps) if $deps;
 

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -280,6 +280,10 @@ You can pipe the list to your CPAN client to install or update them:
 
     dzil authordeps --missing | cpanm
 
+or if your OS does not support pipes:
+
+    dzil authordeps --missing --exe cpanm
+
 END_DIE
 
   };

--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -26,6 +26,7 @@ sub install_author_deps {
   foreach my $rec (@{ $reqs }) {
     my ($mod, $ver) = each(%{ $rec });
     system qq{$command $mod};
+    each(%{ $rec });
   }
   return;
 }

--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -20,6 +20,16 @@ sub format_author_deps {
   return $formatted;
 }
 
+sub install_author_deps {
+  my ($reqs, $command) = @_;
+
+  foreach my $rec (@{ $reqs }) {
+    my ($mod, $ver) = each(%{ $rec });
+    system qq{$command $mod};
+  }
+  return;
+}
+
 sub extract_author_deps {
   my ($root, $missing) = @_;
 


### PR DESCRIPTION
Make it easy to install dependencies even on operating systemis that don't support piping output
of one command to the input of another command.