### PR TITLE
in [NextRelease]: die with a useful error message when the Changes file cannot be found

### DIFF
--- a/lib/Dist/Zilla/Plugin/NextRelease.pm
+++ b/lib/Dist/Zilla/Plugin/NextRelease.pm
@@ -120,6 +120,7 @@ sub after_release {
   my ($self) = @_;
   my $filename = $self->filename;
   my ($gathered_file) = grep { $_->name eq $filename } @{ $self->zilla->files };
+  $self->log_fatal("failed to find $filename in the distribution") if not $gathered_file;
   my $iolayer = sprintf(":raw:encoding(%s)", $gathered_file->encoding);
 
   # read original changelog


### PR DESCRIPTION
remedy for:

16:11 < BooK> Can't call method "encoding" on an undefined value at /home/book/perl5/lib/perl5/Dist/Zilla/Plugin/NextRelease.pm line 121.
16:11 < BooK> not sure what the cause is
16:21 < ether> BooK: it's trying to find the 'Changes' file in the dist so it can change {{$NEXT}} to the timestamp, but no such file was found.
