### PR TITLE
Utils/AuthorDeps.pm: re-write section splitting logic.

### DIFF
--- a/corpus/dist/AuthorDeps/dist.ini
+++ b/corpus/dist/AuthorDeps/dist.ini
@@ -1,0 +1,24 @@
+name    = Foo
+version = 1.23
+author  = foobar
+license = Perl_5
+copyright_holder = foobar
+copyright_year   = 2009
+
+; authordep perl = 5.005
+
+[GatherDir]
+[ExecDir/BadlyPaddedName]
+:version = 5.0
+
+[AutoPrereqs]
+:version = 5.0
+
+skip = ^DZPA::Skip
+[MetaYAML]
+version = 2
+
+[Encoding / WithDescription]
+:version = 5.0
+encoding = bytes
+filename = t/data.bin

--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -37,17 +37,14 @@ sub extract_author_deps {
   require CPAN::Meta::Requirements;
   my $reqs = CPAN::Meta::Requirements->new;
 
-  my @packs =
-    map  { s/\s.*//; $_ }
-    grep { $_ ne '_' }
-    keys %$config;
-
-  foreach my $pack (@packs) {
+  for my $section ( sort keys %$config ) {
+    next if q[_] eq $section;
+    my $pack = $section;
+    $pack =~ s{\s*/.*$}{}; # trim optional space and slash-delimited suffix
 
     my $version = 0;
-    if(exists $config->{$pack} && exists $config->{$pack}->{':version'}) {
-      $version = $config->{$pack}->{':version'};
-    }
+    $version = $config->{$section}->{':version'} if exists $config->{$section}->{':version'};
+
     my $realname = Dist::Zilla::Util->expand_config_package_name($pack);
     $reqs->add_minimum($realname => $version);
   }

--- a/t/commands/authordeps.t
+++ b/t/commands/authordeps.t
@@ -11,7 +11,7 @@ use Path::Class;
 
 my $authordeps =
     Dist::Zilla::Util::AuthorDeps::extract_author_deps(
-	dir('corpus/dist/AutoPrereqs'),
+	dir('corpus/dist/AuthorDeps'),
 	0
     );
 
@@ -19,9 +19,10 @@ is_deeply(
     $authordeps,
     [
       +{ perl => '5.005' },
-      map { +{"Dist::Zilla::Plugin::$_" => 0} } qw<AutoPrereqs Encoding ExecDir GatherDir MetaYAML>,
+      ( map { +{"Dist::Zilla::Plugin::$_" => '5.0'} } qw<AutoPrereqs Encoding ExecDir> ),
+      ( map { +{"Dist::Zilla::Plugin::$_" => 0} } qw<GatherDir MetaYAML> ),
     ],
-    "authordeps in corpus/dist/AutoPrereqs"
+    "authordeps in corpus/dist/AuthorDeps"
 ) or diag explain $authordeps;
 
 done_testing;


### PR DESCRIPTION
Authordeps had 2 largeish mistakes.
##### 1. It figured it could strip everything after a trailing space in a section name.

And then use that stripped name as a key to extract data
from the original section hash and get the version.

This was however wrong, as after stripping the trailing space, it only
looked in an **empty** hash key, which of course, has no version
requirements.

ie:

```
[Extra / Deps]
:version = 1.0
```

Boiled down to

```
$config->{"Extra"}->{':version'}
```

Which didn't exist.

So this resolves gh #353
##### 2. It stripped on space, not on the slash delimiter.

This means it saw

```
[Extra/Deps]
```

And parsed it as

```
{ pack => 'Extra/Deps', name => '' }
```

Where it should have parsed it as

```
{ pack => 'Extra', name => 'Deps' }
```

So this also resolves #196
