### PR TITLE
rewrite [GatherDir] to fix symlink traversal, add a prune_directory option

### DIFF
--- a/t/plugins/gatherdir.t
+++ b/t/plugins/gatherdir.t
@@ -38,6 +38,11 @@ my $tzil = Builder->from_config(
           follow_symlinks => 1,
           prefix => 'links',
         } ],
+        [ GatherDir => PruneDirectory => {
+          root   => '../corpus/extra',
+          prefix => 'pruned',
+          prune_directory => '^subdir$',
+        } ],
         'Manifest',
         'MetaConfig',
       ),
@@ -68,10 +73,11 @@ is_filelist(
     some/vader.txt
     xmatch/vader.txt
     links/vader.txt links/subdir/index.html links/notme.txt
+    pruned/notme.txt pruned/vader.txt
     dist.ini lib/DZT/Sample.pm t/basic.t
     MANIFEST
   ),
-    ($^O ne 'MSWin32' ? (map { $_ . '/vader_link.txt' } qw(bonus dotty some xmatch links)) : ()),
+    ($^O ne 'MSWin32' ? (map { $_ . '/vader_link.txt' } qw(bonus dotty some xmatch links pruned)) : ()),
   ],
   "GatherDir gathers all files in the source dir",
 );


### PR DESCRIPTION
This is split up into several commits for easier review of each atomic change;
you may want to squash some of these together, or even take some of them
separately.
- fix symlink traversal in [GatherDir]
- rewrite [GatherDir] to filter found files with File::Find::Rule rules
- add "prune_directory" option to [GatherDir]: this is much more efficient
  than gathering a directory full of files only to prune it away later -- in
  the Moose repository, where old build directories are quite large, this cut
  the build time from 2m38s to 1m24s.
