### PR TITLE
FIX: root is a Path::Class::Dir: stringify it before dumping to metadata

### DIFF
--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -153,8 +153,9 @@ around dump_config => sub {
   my $config = $self->$orig;
 
   $config->{+__PACKAGE__} = {
-    map { $_ => $self->$_ }
-      qw(root prefix include_dotfiles follow_symlinks exclude_filename exclude_match prune_directory),
+    (map { $_ => $self->$_ }
+      qw(prefix include_dotfiles follow_symlinks exclude_filename exclude_match prune_directory)),
+    root => $self->root . '',
   };
 
   return $config;


### PR DESCRIPTION
(follow-up to changes in 5.021)
