### PR TITLE
document that after_release takes an argument

### DIFF
--- a/lib/Dist/Zilla/Role/AfterRelease.pm
+++ b/lib/Dist/Zilla/Role/AfterRelease.pm
@@ -9,7 +9,7 @@ use namespace::autoclean;
 =head1 DESCRIPTION
 
 Plugins implementing this role have their C<after_release> method called
-once the release is done.
+once the release is done. The archive filename is passed as the sole argument.
 
 =cut
 


### PR DESCRIPTION
Looking at https://github.com/moose/Moose/pull/83, I noticed that it's not instantly obvious that an archive must be built because archive_release is passed its filename.

(I suppose you _could_ add to the public API that this filename might be undef, but that might cause interesting failures with some existing plugins that aren't expecting it.  Dist::Zilla::Plugin::Run::AfterRelease comes to mind.)
