### PR TITLE
print a recognizable success message when the build finishes

### DIFF
--- a/lib/Dist/Zilla/App/Command/build.pm
+++ b/lib/Dist/Zilla/App/Command/build.pm
@@ -65,6 +65,8 @@ sub execute {
     $zilla->is_trial(1) if $opt->trial;
     $zilla->$method;
   }
+
+  $self->log('[DZ] built in ' . $self->zilla->built_in);
 }
 
 1;


### PR DESCRIPTION
some builds print so many diagnostic statements that it's not very clear
whether the build halted midway or it was really successful -- so print
something obvious so we know for sure.
