### PR TITLE
Some log -> log_debug changes to quieten messages that don't tend to be useful.

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -141,7 +141,7 @@ has abstract => (
     }
 
     my $file = $self->main_module;
-    $self->log("extracting distribution abstract from " . $file->name);
+    $self->log_debug("extracting distribution abstract from " . $file->name);
     my $abstract = Dist::Zilla::Util->abstract_from_file($file);
 
     if (!defined($abstract)) {


### PR DESCRIPTION
So far, 
- `main_module` now only `->log`s when guessing,
- `main_module` calls `->log_debug` about the used module in all cases.
- `abstract` calls `->log_debug` instead of `->log` to indicate its getting `abstract` from somewhere else.

There's probably a few more I can clean up, but these ones are the most obvious and seemingly less contravercial ones.
