### PR TITLE
build the prereqs attr lazily

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -540,6 +540,7 @@ has prereqs => (
   is   => 'ro',
   isa  => 'Dist::Zilla::Prereqs',
   init_arg => undef,
+  lazy     => 1,
   default  => sub { Dist::Zilla::Prereqs->new },
   handles  => [ qw(register_prereqs) ],
 );


### PR DESCRIPTION
This gives a tiny efficiency boost when we're not doing a full build, but also lets things like [VerifyPrereqs] be able to tell when something tries to look in $zilla->prereqs prematurely and warn about it.
