### PR TITLE
Include DevelopRequires prereqs in a generated Build.PL

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - the Module::Build plugin now includes any DevelopRequires prereqs in
+          the generated Build.PL file. (Dave Rolsky)
 
 5.023     2014-10-30 22:56:42-04:00 America/New_York
         - optimizations to loading of heavyweight libraries in cmd line app

--- a/lib/Dist/Zilla/Plugin/ModuleBuild.pm
+++ b/lib/Dist/Zilla/Plugin/ModuleBuild.pm
@@ -135,6 +135,7 @@ sub module_build_args {
   my $prereqs = $self->zilla->prereqs;
   my %prereqs = (
     configure_requires => $prereqs->requirements_for(qw(configure requires)),
+    develop_requires   => $prereqs->requirements_for(qw(develop   requires)),
     build_requires     => $prereqs->requirements_for(qw(build     requires)),
     test_requires      => $prereqs->requirements_for(qw(test      requires)),
     requires           => $prereqs->requirements_for(qw(runtime   requires)),

--- a/t/plugins/modulebuild.t
+++ b/t/plugins/modulebuild.t
@@ -14,8 +14,9 @@ use Test::DZil;
           'GatherDir',
           'ModuleBuild',
           [ Prereqs => { 'Foo::Bar' => '1.20' } ],
-          [ Prereqs => BuildRequires => { 'Builder::Bob' => '9.901' } ],
-          [ Prereqs => TestRequires  => { 'Test::Deet'   => '7'     } ],
+          [ Prereqs => BuildRequires   => { 'Builder::Bob' => '9.901' } ],
+          [ Prereqs => DevelopRequires => { 'Devel::Thing' => '42'    } ],
+          [ Prereqs => TestRequires    => { 'Test::Deet'   => '7'     } ],
         ),
       },
     },
@@ -43,6 +44,9 @@ use Test::DZil;
     build_requires => {
       'Builder::Bob'  => '9.901',
       'Module::Build' => '0.28',
+    },
+    develop_requires => {
+      'Devel::Thing' => '42',
     },
     test_requires => {
       'Test::Deet'    => '7',


### PR DESCRIPTION
This fixes a problem with modules which use dzil & MB under travis with the perl-travis-helper. Also, it's just more correct.
