### PR TITLE
Add the ability to specify the directory to mint new dists in

### DIFF
--- a/lib/Dist/Zilla/Role/MintingProfile.pm
+++ b/lib/Dist/Zilla/Role/MintingProfile.pm
@@ -10,7 +10,7 @@ use Path::Class;
 
 =head1 DESCRIPTION
 
-Plugins implementing this role should provide C<profile_dir> method, which,
+Plugins implementing this role should provide the C<profile_dir> method, which,
 given a minting profile name, returns its directory.
 
 The minting profile is a directory, containing arbitrary files used during
@@ -25,8 +25,17 @@ based on your profile with the:
 
   $ dzil new -P Provider -p profile_name Distribution::Name
 
+Furthermore, if the needs of the author is zany enough, they can override the
+C<mint_dir> method, which, given a dist name, returns the directory to create
+and mint the dist in. The default implementation C<mint_dir> uses the dist name.
+
 =cut
 
 requires 'profile_dir';
+
+sub mint_dir {
+  #my ($self, $dist_name) = @_;
+  return $_[1];
+}
 
 1;

--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -219,17 +219,6 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
   use File::Copy::Recursive qw(dircopy);
   use Path::Class;
 
-  sub _mint_target_dir {
-    my ($self) = @_;
-
-    my $name = $self->name;
-    my $dir  = $self->tempdir->subdir('mint')->absolute;
-
-    $self->log_fatal("$dir already exists") if -e $dir;
-
-    return $dir;
-  }
-
   sub _setup_global_config {
     my ($self, $dir, $arg) = @_;
 
@@ -286,6 +275,7 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
     $zilla->_set_tempdir_root($tempdir_root);
     $zilla->_set_tempdir_obj($tempdir_obj);
     $zilla->_set_tempdir($tempdir);
+    $zilla->_mint_target_dir( $zilla->tempdir->subdir('mint')->absolute->stringify );
 
     return $zilla;
   };


### PR DESCRIPTION
I might be zany but I don't like the default naming convention where it uses the dist name as the target directory. For example:

dzil new Foo::Bar # will create Foo-Bar

But I want the dir to be "perl-foo-bar" to differentiate my repos and to reduce the strain on my hands when typing :) I've come up with a solution that isn't invasive and preserves the default. I checked on grep.cpan.me and nothing matches "_mint_target_dir" so I think it's ok to munge it a bit, ha!

In my MintingProfile::Author::APOCAL I'll simply set:

sub mint_dir {
  return 'perl-' . lc( $_[1] );
}

Looks simple, eh? Thanks again for looking into this!
