### PR TITLE
new filefinder :PerlExecFiles

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Revision history for {{$dist->name}}
         - dzil listdeps --develop now exists as an alias for dzil listdeps
           --author (Karen Etheridge)
         - PkgVersion now skips .pod files (David Golden)
+        - new file finder ':PerlExecFiles'
 
 5.037     2015-06-04 21:46:38-04:00 America/New_York
         - issue a warning when version ranges are passed through to

--- a/corpus/dist/DZT_Bin/another_perl_script
+++ b/corpus/dist/DZT_Bin/another_perl_script
@@ -1,0 +1,4 @@
+#!/usr/bin/perl
+print "Hello World!\n";
+exit;
+

--- a/corpus/dist/DZT_Bin/test.bash
+++ b/corpus/dist/DZT_Bin/test.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+echo 'Hello World!'
+

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -116,6 +116,25 @@ sub _setup_default_plugins {
     push @{ $self->plugins }, $plugin;
   }
 
+  unless ($self->plugin_named(':PerlExecFiles')) {
+    require Dist::Zilla::Plugin::FinderCode;
+    my $plugin = Dist::Zilla::Plugin::FinderCode->new({
+      plugin_name => ':PerlExecFiles',
+      zilla       => $self,
+      style       => 'list',
+      code        => sub {
+        my $parent_plugin = $self->plugin_named(':ExecFiles');
+        my @files = grep {
+          $_->name =~ m{\.pl$}
+              or $_->content =~ m{^\s*\#\!.*perl\b};
+        } @{ $parent_plugin->find_files };
+        return \@files;
+      },
+    });
+
+    push @{ $self->plugins }, $plugin;
+  }
+
   unless ($self->plugin_named(':ShareFiles')) {
     require Dist::Zilla::Plugin::FinderCode;
     my $plugin = Dist::Zilla::Plugin::FinderCode->new({

--- a/lib/Dist/Zilla/Role/FileFinderUser.pm
+++ b/lib/Dist/Zilla/Role/FileFinderUser.pm
@@ -72,6 +72,11 @@ Searches your t/ directory and lists the files in it.
 Searches your distribution for executable files.  Hint: Use the
 L<Dist::Zilla::Plugin::ExecDir> plugin to mark those files as executables.
 
+= :PerlExecFiles
+
+A subset of C<:ExecFiles> limited just to perl scripts (those ending with
+F<.pl>, or with a recognizable perl shebang).
+
 = :ShareFiles
 
 Searches your ShareDir directory and lists the files in it.

--- a/t/plugins/filefinders.t
+++ b/t/plugins/filefinders.t
@@ -47,6 +47,8 @@ is_filelist(
     t/basic.t
     MANIFEST
     inc/Foo.pm inc/Foo/Bar.pm
+    bin/another_perl_script
+    bin/test.bash
     bin/test.pl
   ) ],
   "GatherDir gathers all files in the source dir",
@@ -90,9 +92,21 @@ $files = $tzil->find_files(':ExecFiles');
 is_filelist(
   [ map {; $_->name } @$files ],
   [ qw(
+    bin/another_perl_script
+    bin/test.bash
     bin/test.pl
   ) ],
   "ExecFiles finds all files",
+);
+
+$files = $tzil->find_files(':PerlExecFiles');
+is_filelist(
+  [ map {; $_->name } @$files ],
+  [ qw(
+    bin/another_perl_script
+    bin/test.pl
+  ) ],
+  "PerlExecFiles finds exec files that are perl",
 );
 
 $files = $tzil->find_files(':ShareFiles');


### PR DESCRIPTION
As discussed in https://rt.cpan.org/Ticket/Display.html?id=100322, and will likely be used as a default in [Test::Compile].

@apocalypse @dagolden