### PR TITLE
add license module prerequirement to authordeps

### DIFF
--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -36,6 +36,12 @@ sub extract_author_deps {
   require CPAN::Meta::Requirements;
   my $reqs = CPAN::Meta::Requirements->new;
 
+  my $license = $config->{_}->{license};
+  if (defined $license) {
+    $license = 'Software::License::'.$license;
+    $reqs->add_minimum($license => 0);
+  }
+
   for my $section ( sort keys %$config ) {
     next if q[_] eq $section;
     my $pack = $section;

--- a/t/commands/authordeps.t
+++ b/t/commands/authordeps.t
@@ -19,6 +19,7 @@ is_deeply(
       +{ perl => '5.005' },
       ( map { +{"Dist::Zilla::Plugin::$_" => '5.0'} } qw<AutoPrereqs Encoding ExecDir> ),
       ( map { +{"Dist::Zilla::Plugin::$_" => 0} } qw<GatherDir MetaYAML> ),
+      +{ 'Software::License::Perl_5' => '0' },
     ],
     "authordeps in corpus/dist/AuthorDeps"
 ) or diag explain $authordeps;


### PR DESCRIPTION
In cases where not a regular Software::License module is needed, but another one, dzil will fail directly after ```[DZ] beginning to build Dist-Zilla``` with a ```Can't locate Software/License/XXX.pm``` message. The missing module is *not* listed in ```dzil authordeps```.

The usual workaroud is to explicitly add a ```; authordep Software::License::XXX``` line in dist.ini.

This PR solves this issue by adding the license module to the authordeps list.