### PR TITLE
[NextRelease]: use the original Changes content as a base for munging, rather than whatever is in the repo after release

### DIFF
--- a/t/plugins/nextrelease.t
+++ b/t/plugins/nextrelease.t
@@ -21,7 +21,7 @@ END_CHANGES
 
 {
   my $tzil = Builder->from_config(
-    { dist_root => 'corpus/dist/DZT' },
+    { dist_root => 'does/not/exist' },
     {
       add_files => {
         'source/Changes' => $changes,
@@ -36,6 +36,12 @@ END_CHANGES
     $tzil->slurp_file('build/Changes'),
     qr{0\.001},
     "new version appears in build Changes file",
+  );
+
+  unlike(
+    $tzil->slurp_file('build/Changes'),
+    qr/\{\{\$NEXT\}\}/,
+    "template variable does not appear in build Changes file",
   );
 
   unlike(
@@ -54,8 +60,8 @@ END_CHANGES
 
   like(
     $tzil->slurp_file('source/Changes'),
-    qr{0\.001},
-    "new version appears in source Changes file after release",
+    qr{\{\{\$NEXT\}\}\s+0\.001},
+    "new version appears in source Changes file after release, below template variable",
   );
 
   ok(

--- a/t/plugins/nextrelease.t
+++ b/t/plugins/nextrelease.t
@@ -20,12 +20,22 @@ Revision history for {{$dist->name}}
 END_CHANGES
 
 {
+  package inc::TrashChanges;
+  use Moose;
+  with 'Dist::Zilla::Role::AfterRelease';
+
+  sub after_release {
+    Path::Tiny::path('Changes')->spew('OHHAI');
+  }
+}
+
+{
   my $tzil = Builder->from_config(
     { dist_root => 'does/not/exist' },
     {
       add_files => {
         'source/Changes' => $changes,
-        'source/dist.ini' => simple_ini(qw(GatherDir NextRelease FakeRelease)),
+        'source/dist.ini' => simple_ini(qw(GatherDir =inc::TrashChanges NextRelease FakeRelease)),
       },
     },
   );


### PR DESCRIPTION
This allows other AfterRelease plugins to copy the Changes file from the built
distribution back to the repo and commit it, before we add in the {{$NEXT}}
line here.

This lets us commit the Changes file at the release tag exactly how it appears in the shipped dist.

