### PR TITLE
also check for the existence of $Package::Name::VERSION in the code before adding another one

### DIFF
--- a/lib/Dist/Zilla/Plugin/PkgDist.pm
+++ b/lib/Dist/Zilla/Plugin/PkgDist.pm
@@ -55,12 +55,15 @@ sub munge_perl {
 
   my $document = $self->ppi_document_for_file($file);
 
-  if ($self->document_assigns_to_variable($document, '$DIST')) {
-    $self->log([ 'skipping %s: assigns to $DIST', $file->name ]);
-    return;
-  }
-
   return unless my $package_stmts = $document->find('PPI::Statement::Package');
+
+  for my $prefix ('', map { $_->namespace . '::' } @$package_stmts) {
+    my $variable = '$' . $prefix . 'DIST';
+    if ($self->document_assigns_to_variable($document, $variable)) {
+      $self->log([ 'skipping %s: assigns to %s', $file->name, $variable ]);
+      return;
+    }
+  }
 
   my %seen_pkg;
 

--- a/t/plugins/pkgdist.t
+++ b/t/plugins/pkgdist.t
@@ -11,6 +11,12 @@ our $DIST = \'DZT-Blort\';
 1;
 ';
 
+my $with_dist_fully_qualified = '
+package DZT::WDistFullyQualified;
+$DZT::WDistFullyQualified::DIST = \'DZT-Blort\';
+1;
+';
+
 my $two_packages = '
 package DZT::TP1;
 
@@ -56,6 +62,7 @@ my $tzil = Builder->from_config(
     add_files => {
       'source/lib/DZT/TP1.pm'    => $two_packages,
       'source/lib/DZT/WDist.pm'  => $with_dist,
+      'source/lib/DZT/WDistFullyQualified.pm' => $with_dist_fully_qualified,
       'source/lib/DZT/R1.pm'     => $repeated_packages,
       'source/lib/DZT/Monkey.pm' => $monkey_patched,
       'source/bin/script_pkg.pl' => $script_pkg,
@@ -92,6 +99,13 @@ my $dzt_wdist = $tzil->slurp_file('build/lib/DZT/WDist.pm');
 unlike(
   $dzt_wdist,
   qr{^\s*\$\QDZT::WDist::DIST = 'DZT-Sample';\E\s*$}m,
+  "*not* added to DZT::WDist; we have one already",
+);
+
+my $dzt_wdist_fully_qualified = $tzil->slurp_file('build/lib/DZT/WDistFullyQualified.pm');
+unlike(
+  $dzt_wdist_fully_qualified,
+  qr{^\s*\$\QDZT::WDistFullyQualified::DIST = 'DZT-Sample';\E\s*$}m,
   "*not* added to DZT::WDist; we have one already",
 );
 

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -18,6 +18,12 @@ $VERSION = 1.234;
 1;
 ';
 
+my $with_version_fully_qualified = '
+package DZT::WVerFullyQualified;
+$DZT::WVerFullyQualified::VERSION = 1.234;
+1;
+';
+
 my $in_a_string_escaped = '
 package DZT::WStrEscaped;
 print "\$VERSION = 1.234;"
@@ -122,6 +128,7 @@ my $tzil = Builder->from_config(
       'source/lib/DZT/TP1.pm'    => $two_packages,
       'source/lib/DZT/WVer.pm'   => $with_version,
       'source/lib/DZT/WVerTwoLines.pm' => $with_version_two_lines,
+      'source/lib/DZT/WVerFullyQualified.pm' => $with_version_fully_qualified,
       'source/lib/DZT/WStrEscaped.pm'  => $in_a_string_escaped,
       'source/lib/DZT/WInComment.pm' => $in_comment,
       'source/lib/DZT/WInCommentInSub.pm' => $in_comment_in_sub,
@@ -173,6 +180,13 @@ unlike(
   $dzt_wver_two_lines,
   qr{^\s*\$\QDZT::WVerTwoLines::VERSION = '0.001';\E\s*$}m,
   "*not* added to DZT::WVerTwoLines; we have one already",
+);
+
+my $dzt_wver_fully_qualified = $tzil->slurp_file('build/lib/DZT/WVerFullyQualified.pm');
+unlike(
+  $dzt_wver_fully_qualified,
+  qr{^\s*\$\QDZT::WVerFullyQualified::VERSION = '0.001';\E\s*$}m,
+  "*not* added to DZT::WVer; we have one already",
 );
 
 my $dzt_wver_in_comment = $tzil->slurp_file('build/lib/DZT/WInComment.pm');


### PR DESCRIPTION
(not related to #382 except that the changes here made me realize the errors that are fixed here.)

Does not change behaviour in the success case -- only properly identifies that $Foo::VERSION in the package means that another one should not be added by [PkgVersion](ironically, the exact form that it adds -- so it is quite possible to use [PkgVersion] twice!).
