### PR TITLE
Fix FilePruner plugins array mutation bug

### DIFF
--- a/lib/Dist/Zilla/Plugin/ManifestSkip.pm
+++ b/lib/Dist/Zilla/Plugin/ManifestSkip.pm
@@ -63,7 +63,8 @@ sub prune_files {
 
   my $skip = ExtUtils::Manifest::maniskip($skipfile_name);
 
-  for my $file (sort @{ $files }) {
+  # Copy list (break reference) so we can mutate.
+  for my $file ((), @{ $files }) {
     next unless $skip->($file->name);
 
     $self->log_debug([ 'pruning %s', $file->name ]);

--- a/lib/Dist/Zilla/Plugin/PruneCruft.pm
+++ b/lib/Dist/Zilla/Plugin/PruneCruft.pm
@@ -86,7 +86,8 @@ sub exclude_file {
 sub prune_files {
   my ($self) = @_;
 
-  for my $file (@{ $self->zilla->files }) {
+  # Copy list (break reference) so we can mutate.
+  for my $file ((), @{ $self->zilla->files }) {
     next unless $self->exclude_file($file);
 
     $self->log_debug([ 'pruning %s', $file->name ]);

--- a/lib/Dist/Zilla/Plugin/PruneFiles.pm
+++ b/lib/Dist/Zilla/Plugin/PruneFiles.pm
@@ -66,7 +66,8 @@ sub prune_files {
   # \A\Q$_\E should also handle the `eq` check
   $matches_regex = qr/$matches_regex|\A\Q$_\E/ for (@{ $self->filenames });
 
-  for my $file (@{ $self->zilla->files }) {
+  # Copy list (break reference) so we can mutate.
+  for my $file ((), @{ $self->zilla->files }) {
     next unless $file->name =~ $matches_regex;
 
     $self->log_debug([ 'pruning %s', $file->name ]);

--- a/t/plugins/prunes.t
+++ b/t/plugins/prunes.t
@@ -168,7 +168,6 @@ for my $skip_skip (0..1) {
 }
 
 {
-  local $TODO = 'Fix bug causing Pruners to skip some files';
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },
     {
@@ -221,7 +220,6 @@ for my $arg (qw(filename filenames)) {
 }
 
 {
-  local $TODO = 'Fix bug causing Pruners to skip some files';
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },
     {


### PR DESCRIPTION
Looks like this was caused by f9cfe8db0c4ba99066e711fcfd1998f061adab39.

If you'd prefer a different style (prune after the loop or whatever), let me know.
