### PR TITLE
fix [GatherDir] handling of symlinks to directories

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - fixed [GatherDir]'s handling of symlinks to directories
 
 5.029     2014-12-14 14:44:44-05:00 America/New_York
         - fix new error in [PkgVersion] when a module had no package

--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -86,9 +86,12 @@ has include_dotfiles => (
 
 =attr follow_symlinks
 
-By default, directories that are symlinks will not be followed. Note on the
-other hand that in all followed directories, files which are symlinks are
-always gathered.
+By default, symlinks pointing to directories will not be followed; set
+C<< follow_symlinks = 1 >> to traverse these links as if they were normal
+directories.
+
+In all followed directories, files which are symlinks are B<always> gathered,
+with the link turning into a normal file.
 
 =cut
 
@@ -183,7 +186,15 @@ sub gather_files {
     $rule->new,
   );
 
-  $rule->or($rule->new->file, $rule->new->symlink);
+  if ($self->follow_symlinks) {
+    $rule->or(
+      $rule->new->file,     # symlinks to files still count as files
+      $rule->new->symlink,  # traverse into the linked dir, but screen it out later
+    );
+  } else {
+    $rule->file;
+  }
+
   $rule->not_exec(sub { /^\.[^.]/ }) unless $self->include_dotfiles;   # exec passes basename as $_
   $rule->exec(sub {
     my $relative = path($_[-1])->relative($root);
@@ -192,6 +203,8 @@ sub gather_files {
   });
 
   FILE: for my $filename ($rule->in($root)) {
+    next if -d $filename;
+
     # _file_from_filename is overloaded in GatherDir::Template
     my $fileobj = $self->_file_from_filename($filename);
 

--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -173,11 +173,12 @@ sub gather_files {
   my $prune_regex = qr/\000/;
   $prune_regex = qr/$prune_regex|$_/
     for ( @{ $self->prune_directory },
-          $self->include_dotfiles ? () : ( qr/^\.[^.]/ ) );
+      $self->include_dotfiles ? () : ( qr/^\.[^.]/ ) );
 
   # build up the rules
   my $rule = File::Find::Rule->new();
-  $rule->extras({follow => $self->follow_symlinks});
+  $rule->extras({ follow => $self->follow_symlinks });
+
   $rule->exec(sub { $self->log_debug('considering ' . path($_[-1])->relative($root)); 1 })
     if $self->zilla->logger->get_debug;
 


### PR DESCRIPTION
as seen on irc:

    14:36 < kentnl> ether: yeah, it adds the symlink as a file in addition to following it 
    14:36 < kentnl> ( in the event the symlink is a dir symlink )
