### PR TITLE
be a bit more selective when scanning for local namespaces

### DIFF
--- a/corpus/dist/AutoPrereqs/lib/DZPA/Main.pm
+++ b/corpus/dist/AutoPrereqs/lib/DZPA/Main.pm
@@ -49,6 +49,9 @@ use parent -norequire => 'DZPA::Second';
 
 use DZPA::Empty;
 
+package # hide from PAUSE
+    DZPA::Fourth;
+
 
 __END__
 =head1 FOO

--- a/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
@@ -183,6 +183,7 @@ sub register_prereqs {
       }
       s{\.pm$}{} for @this_thing;
       s{/}{::}g for @this_thing;
+      @this_thing = List::MoreUtils::uniq grep { /^\w+(?:(?:'|::)\w+)*$/ } @this_thing;
 
       # this is a bunk heuristic and can still capture strings from pod - the
       # proper thing to do is grab all packages from Module::Metadata
@@ -208,7 +209,8 @@ sub register_prereqs {
     }
 
     # remove prereqs shipped with current dist
-    $self->log_debug([ 'excluding local packages: %s', sub { join(', ', List::Util::uniq @modules) } ]);
+    @modules = List::Util::uniq(@modules);
+    $self->log_debug([ 'excluding local packages: %s', sub { join(', ', @modules) } ]);
     $req->clear_requirement($_) for @modules;
 
     $req->clear_requirement($_) for qw(Config DB Errno NEXT Pod::Functions); # never indexed


### PR DESCRIPTION
This screens out things like "t::00-report-prereqs.t" (translated from
filenames) and '#' (from "package # hide from PAUSE").

(a follow-up from the change to AutoPrereqs in 5.030.)