### PR TITLE
Emit dist_ini()s generated text with payload keys sorted.

### DIFF
--- a/lib/Test/DZil.pm
+++ b/lib/Test/DZil.pm
@@ -113,7 +113,7 @@ sub _build_ini_builder {
 
     my $config = '';
 
-    for my $key (keys %$core_config) {
+    for my $key (sort keys %$core_config) {
       my @values = ref $core_config->{ $key }
                  ? @{ $core_config->{ $key } }
                  : $core_config->{ $key };
@@ -135,7 +135,7 @@ sub _build_ini_builder {
       $config .= ' / ' . $name if defined $name;
       $config .= "]\n";
 
-      for my $key (keys %$payload) {
+      for my $key (sort keys %$payload) {
         my @values = ref $payload->{ $key }
                    ? @{ $payload->{ $key } }
                    : $payload->{ $key };

--- a/t/tester-sort.t
+++ b/t/tester-sort.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+use Test::DZil;
+
+my @pass_one = split /\n/, simple_ini();
+my @pass_two = split /\n/, simple_ini();
+
+is_deeply(\@pass_one, \@pass_two,  "Multiple calls to simple_ini are in the same order");
+
+done_testing;


### PR DESCRIPTION
This makes the output format more stable, in the event that anything
needs to round-trip those files through some process and recompare them.

For instance, in the case of bakeini, it retains input order and only expands bundles.

Thus, testing bakeini is made more complicated by dist_ini() having a
random order of each payload key, that can only otherwise be tested by a
full parse instead of a simple line-by-line comparison.