### PR TITLE
Documented 'version' attribute in Dist::Zilla::PluginBundle::Filter

### DIFF
--- a/lib/Dist/Zilla/PluginBundle/Filter.pm
+++ b/lib/Dist/Zilla/PluginBundle/Filter.pm
@@ -16,6 +16,7 @@ In your F<dist.ini>:
 
   [@Filter]
   -bundle = @Basic
+  -version = 5.031
   -remove = ShareDir
   -remove = UploadToCPAN
   option = for_basic
@@ -25,6 +26,9 @@ In your F<dist.ini>:
 This plugin bundle actually wraps and modifies another plugin bundle.  It
 includes all the configuration for the bundle named in the C<-bundle> attribute,
 but removes all the entries whose package is given in the C<-remove> attributes.
+
+A minimum required version of the bundle can be specified with the C<-version> 
+attribute.
 
 Options not prefixed with C<-> will be passed to the bundle to be filtered.
 


### PR DESCRIPTION
Noticed this wasn't documented (and no comment in code to suggest not to use it)

thanks,
Michael