### PR TITLE
also prune the new _eumm directory

### DIFF
--- a/lib/Dist/Zilla/Plugin/PruneCruft.pm
+++ b/lib/Dist/Zilla/Plugin/PruneCruft.pm
@@ -70,6 +70,7 @@ sub exclude_file {
   return 1 if $file->name eq 'MYMETA.yml';
   return 1 if $file->name eq 'MYMETA.json';
   return 1 if $file->name eq 'pm_to_blib';
+  return 1 if substr($file->name, 0, 6) eq '_eumm/';
   # Avoid bundling fatlib/ dir created by App::FatPacker
   # https://github.com/andk/pause/pull/65
   return 1 if substr($file->name, 0, 7) eq 'fatlib/';


### PR DESCRIPTION
This directory is created by ExtUtils::MakeMaker starting with version
7.05_05, via this commit:
Perl-Toolchain-Gang/ExtUtils-MakeMaker@b6a9eba

It was added to the default MANIFEST.SKIP in ExtUtils::Manifest 1.70, here:
Perl-Toolchain-Gang/ExtUtils-Manifest@e0f4457