### PR TITLE
main_module lookup improvements

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -192,10 +192,10 @@ has main_module => (
         $file = first { $_->name eq $override }
                 @{ $self->files };
     } else {
-       # We're having to guess
+        # We're having to guess
 
-       ($guess = $self->name) =~ s{-}{/}g;
-       $guess = "lib/$guess.pm";
+        ($guess = $self->name) =~ s{-}{/}g;
+        $guess = "lib/$guess.pm";
 
         # Look for $guess among modules in lib/
         my %modules;
@@ -217,7 +217,7 @@ has main_module => (
                   (sort { length($a) <=> length($b) }
                   keys %modules)[0] };
         }
-       $self->log("guessing dist's main_module is " . ($file ? $file->name : $guess));
+        $self->log("guessing dist's main_module is " . ($file ? $file->name : $guess));
     }
 
     if (not $file) {

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -215,7 +215,7 @@ has main_module => (
         }
         if ( not @{ $self->files } ) {
             push @errorlines, "Upon further inspection we didn't find any files in your dist, did you add any?";
-        } elsif ( none { $_->name =~ m{\.pm\z} } @{ $self->files } ){
+        } elsif ( none { $_->name =~ m{^lib/.+\.pm\z} } @{ $self->files } ){
             push @errorlines, "We didn't find any .pm files in your dist, this is probably a problem.";
         }
         push @errorlines,"Cannot continue without a main_module";


### PR DESCRIPTION
Improvements of the `main_module` lookup:
* show the reason why the guessing failed even if a .pm exists outside `lib/`
* refactoring: faster guessing
* fix indent around previous changes in otherwise untouched code