### PR TITLE
add use_begin option in the PkgVersion plugin, to re-enable BEGIN { $VERSION= }

### DIFF
--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -65,6 +65,13 @@ with some analyzers.  Use of this feature is deprecated.
 
 Something else will replace it in the future.
 
+=attr use_begin
+
+The idea here is to wrap the version assignment in a BEGIN bloc. This helps
+when using dist.ini in distribution that contains XS code, and where DynaLoader
+has t be called at BEGIN time, and requires VERSION. Yes, there are intrepid
+heroes that are using Dist::Zilla with XS code. Defaults is false.
+
 =attr finder
 
 =for stopwords FileFinder
@@ -117,6 +124,12 @@ has die_on_line_insertion => (
 );
 
 has use_our => (
+  is  => 'ro',
+  isa => 'Bool',
+  default => 0,
+);
+
+has use_begin => (
   is  => 'ro',
   isa => 'Bool',
   default => 0,
@@ -176,6 +189,9 @@ sub munge_perl {
     my $perl = $self->use_our
         ? "{ our \$VERSION\x20=\x20'$version'; }$trial"
         : "\$$package\::VERSION\x20=\x20'$version';$trial";
+
+    $self->use_begin
+      and $perl = "BEGIN { $perl }";
 
     $self->log_debug([
       'adding $VERSION assignment to %s in %s',

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -394,5 +394,25 @@ like(
   '$VERSION inserted by the first plugin is detected by the second',
 );
 
+my $tzil4 = Builder->from_config(
+  { dist_root => 'corpus/dist/DZT' },
+  {
+    add_files => {
+      'source/lib/DZT/TPW.pm'    => $two_packages_weird,
+      'source/dist.ini' => simple_ini('GatherDir', 'PkgVersion', 'ExecDir'),
+    },
+  },
+);
+$tzil4->plugins->[1]->{use_begin} = 1;
+$tzil4->build;
+
+my $dzt_tpw4 = $tzil4->slurp_file('build/lib/DZT/TPW.pm');
+like(
+  $dzt_tpw4,
+  qr{^\s*BEGIN\s*\{ \$DZT::TPW1::VERSION = '0\.001'; \}\s*$}m,
+  "added 'begin' version to DZT::TPW1",
+);
+
+
 done_testing;
 


### PR DESCRIPTION
commit 62e97df removed the feature of having VERSION set in a BEGIN block. It turns out that some people *do* use Dist::Zilla to build XS packages, and they need XSLoader to happen at BEGIN time, with VERSION already set.

This PR is for instance required for the following re-engine-pcre PR:  https://github.com/avar/re-engine-pcre/pull/2

Thanks !