### PR TITLE
build prep: add error checking and handle non-blocking rmdir on Path::Class::Dir::rmtree

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -525,7 +525,10 @@ sub _prep_build_root {
 
   my $dist_root = $self->root;
 
-  $build_root->rmtree if -d $build_root;
+  return $build_root if !-d $build_root;
+
+  my $res = $build_root->rmtree; # this warns with error details
+  die "unable to delete '$build_root' in preparation of build" if !$res;
 
   return $build_root;
 }

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -530,6 +530,17 @@ sub _prep_build_root {
   my $res = $build_root->rmtree; # this warns with error details
   die "unable to delete '$build_root' in preparation of build" if !$res;
 
+  # the following is done only on windows, and only if the deletion failed,
+  # yet rmtree reported success, because currently rmdir is non-blocking as per:
+  # https://rt.perl.org/Ticket/Display.html?id=123958
+  if ( $^O eq 'MSWin32' and -d $build_root ) {
+    $self->log("spinning for at least one second to allow other processes to release locks on $build_root");
+    my $timeout = time + 2;
+    while(time != $timeout and -d $build_root) { }
+    die "unable to delete '$build_root' in preparation of build because some process has a lock on it"
+      if -d $build_root;
+  }
+
   return $build_root;
 }
 


### PR DESCRIPTION
Oh jeeze, forgot the description.

For one, rmtree in that code was completely unchecked. This adds a check in a commit that's likely to be completely uncontroversial.

For the other, as covered in https://rt.perl.org/Ticket/Display.html?id=123958 , rmdir and thus rmtree are non-blocking on windows. This adds code to handle that gracefully with a 1-2 second cpu spin.