### PR TITLE
Make release status configurable

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -54,6 +54,9 @@ remove = Some::Package::That::Does::Not::Exist::Due::To::A::Typo
 [Breaks]
 Dist::Zilla::Plugin::MakeMaker::Awesome = < 0.22
 Dist::Zilla::App::Command::stale = < 0.040
+Dist::Zilla::Plugin::TrialVersionComment = <= 0.003
+Dist::Zilla::Plugin::Run = <= 0.034
+Dist::Zilla::App::Command::update = <= 0.04
 
 [Test::CheckBreaks]
 conflicts_module = Moose::Conflicts

--- a/lib/Dist/Zilla/App/Command/build.pm
+++ b/lib/Dist/Zilla/App/Command/build.pm
@@ -61,8 +61,13 @@ sub execute {
     $self->zilla->build_in($opt->in);
   } else {
     my $method = $opt->tgz ? 'build_archive' : 'build';
-    $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
-    my $zilla  = $self->zilla;
+    my $zilla;
+    {
+      local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
+      $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
+      $zilla  = $self->zilla;
+      $zilla->release_status; # initialize before running method
+    }
     $zilla->$method;
   }
 

--- a/lib/Dist/Zilla/App/Command/build.pm
+++ b/lib/Dist/Zilla/App/Command/build.pm
@@ -61,8 +61,8 @@ sub execute {
     $self->zilla->build_in($opt->in);
   } else {
     my $method = $opt->tgz ? 'build_archive' : 'build';
+    $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
     my $zilla  = $self->zilla;
-    $zilla->is_trial(1) if $opt->trial;
     $zilla->$method;
   }
 

--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -27,9 +27,13 @@ sub opt_spec {
 sub execute {
   my ($self, $opt, $arg) = @_;
 
-  $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
-
-  my $zilla = $self->zilla;
+  my $zilla;
+  {
+    local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
+    $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
+    $zilla = $self->zilla;
+    $zilla->release_status; # initialize before running method
+  }
 
   $self->zilla->release;
 }

--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -27,9 +27,9 @@ sub opt_spec {
 sub execute {
   my ($self, $opt, $arg) = @_;
 
-  my $zilla = $self->zilla;
+  $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
 
-  $zilla->is_trial(1) if $opt->trial;
+  my $zilla = $self->zilla;
 
   $self->zilla->release;
 }

--- a/lib/Dist/Zilla/Role/ReleaseStatusProvider.pm
+++ b/lib/Dist/Zilla/Role/ReleaseStatusProvider.pm
@@ -1,0 +1,27 @@
+package Dist::Zilla::Role::ReleaseStatusProvider;
+# ABSTRACT: something that provides a release status for the dist
+
+use Moose::Role;
+with 'Dist::Zilla::Role::Plugin';
+
+use namespace::autoclean;
+
+=head1 DESCRIPTION
+
+Plugins implementing this role must provide a C<provide_release_status>
+method that will be called when setting the dist's version.
+
+If C<provides_release_status> returns undef, it will be ignored.
+
+=cut
+
+requires 'provide_release_status';
+
+1;
+
+=head1 SEE ALSO
+
+Core Dist::Zilla plugins implementing this role:
+L<AutoVersion|Dist::Zilla::Plugin::AutoVersion>.
+
+=cut

--- a/lib/Dist/Zilla/Types.pm
+++ b/lib/Dist/Zilla/Types.pm
@@ -13,7 +13,7 @@ that's what you want.
 
 =cut
 
-use MooseX::Types -declare => [qw(License OneZero YesNoStr)];
+use MooseX::Types -declare => [qw(License OneZero YesNoStr ReleaseStatus)];
 use MooseX::Types::Moose qw(Str Int);
 
 subtype License, as class_type('Software::License');
@@ -21,6 +21,8 @@ subtype License, as class_type('Software::License');
 subtype OneZero, as Str, where { $_ eq '0' or $_ eq '1' };
 
 subtype YesNoStr, as Str, where { /\A(?:y|ye|yes)\Z/i or /\A(?:n|no)\Z/i };
+
+subtype ReleaseStatus, as Str, where { /\A(?:stable|testing|unstable)\z/ };
 
 coerce OneZero, from YesNoStr, via { /\Ay/i ? 1 : 0 };
 

--- a/t/lib/Dist/Zilla/Plugin/TestReleaseProvider.pm
+++ b/t/lib/Dist/Zilla/Plugin/TestReleaseProvider.pm
@@ -1,0 +1,11 @@
+package Dist::Zilla::Plugin::TestReleaseProvider;
+
+use Moose;
+with(
+  'Dist::Zilla::Role::ReleaseStatusProvider',
+);
+
+sub provide_release_status { 'unstable' }
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/t/plugins/release_status.t
+++ b/t/plugins/release_status.t
@@ -1,0 +1,135 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+use Test::Fatal;
+
+use lib 't/lib';
+
+use Test::DZil;
+use JSON::MaybeXS;
+
+# protect from dzil's own release environment
+local $ENV{RELEASE_STATUS};
+local $ENV{TRIAL};
+
+# TestReleaseProvider sets 'unstable'
+subtest "TestReleaseProvider" => sub {
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          'GatherDir',
+          'MetaJSON',
+          'TestReleaseProvider',
+        ),
+      },
+    },
+  );
+
+  $tzil->build;
+
+  is($tzil->release_status, 'unstable', "release status set from provider");
+  ok($tzil->is_trial, "is_trial is true");
+  like($tzil->archive_filename, qr/-TRIAL/, "-TRIAL in archive filename");
+
+  my $json = $tzil->slurp_file('build/META.json');
+  my $meta = JSON::MaybeXS->new(utf8 => 0)->decode($json);
+  is( $meta->{release_status}, 'unstable', "release status set in META" );
+};
+
+for my $c ( qw/true false/ ) {
+    subtest "is_trial in dist.ini $c" => sub {
+        my $tzil = Builder->from_config(
+            { dist_root => 'corpus/dist/DZT' },
+            {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                { is_trial => $c eq 'true' ? '1' : '0' },
+                'GatherDir',
+                ),
+            },
+            },
+        );
+
+        $tzil->build;
+
+        my $expect = $c eq 'true' ? 'testing' : 'stable';
+        my $is_trial = $expect eq 'testing' ? 1 : 0;
+
+        is($tzil->release_status, $expect, "release status set from is_trial");
+        if ( $is_trial ) {
+            ok($tzil->is_trial, "is_trial is true");
+            like($tzil->archive_filename, qr/-TRIAL/, "-TRIAL in archive filename");
+        }
+        else {
+            ok(! $tzil->is_trial, "is_trial is not true");
+            unlike($tzil->archive_filename, qr/-TRIAL/, "-TRIAL not in archive filename");
+        }
+
+    };
+}
+
+subtest "RELEASE_STATUS" => sub {
+  local $ENV{RELEASE_STATUS} = 'stable';
+  local $ENV{TRIAL} = 1;
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          'GatherDir',
+          'TestReleaseProvider',
+        ),
+      },
+    },
+  );
+
+  $tzil->build;
+
+  is($tzil->release_status, 'stable', "release status set from environment");
+  ok(! $tzil->is_trial, "is_trial is not true");
+  unlike($tzil->archive_filename, qr/-TRIAL/, "-TRIAL not in archive filename");
+};
+
+subtest "TRIAL" => sub {
+  local $ENV{TRIAL} = 1;
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          'GatherDir',
+          'TestReleaseProvider',
+        ),
+      },
+    },
+  );
+
+  $tzil->build;
+
+  is($tzil->release_status, 'testing', "release status set from environment");
+  ok($tzil->is_trial, "is_trial is true");
+  like($tzil->archive_filename, qr/-TRIAL/, "-TRIAL in archive filename");
+};
+
+subtest "too many providers" => sub {
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          { is_trial => '1' }, 'GatherDir', 'TestReleaseProvider',
+        ),
+      },
+    },
+  );
+
+  like(
+    exception { $tzil->build },
+    qr/attempted to set release status twice/,
+    "setting too many times is fatal",
+  );
+};
+
+done_testing;


### PR DESCRIPTION
This change introduces a new attribute, 'release_status', and a new
role, D::Z::R::ReleaseStatusProvider.

The 'is_trial' variable is changed to be read-only.  This will break the
handful of CPAN modules that try to set it.  Those modules should set
the RELEASE_STATUS environment variable before building instead.

For backwards compatibility, 'is_trial' in dist.ini and the TRIAL
environment variable are supported.
