### PR TITLE
add 'ignore' attribute to Plugin::Encoding

### DIFF
--- a/t/plugins/encoding.t
+++ b/t/plugins/encoding.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+use utf8;
+
+use autodie;
+use Test::DZil;
+
+my $ini = <<'END_INI';
+license = Perl_5
+author = E. Xavier Ample <example@example.org>
+abstract = Sample DZ Dist
+name = DZT-Sample
+copyright_holder = E. Xavier Ample
+version = 0.001
+
+[GatherDir]
+
+[Encoding / general]
+encoding=utf8
+match=^
+ignore=^t/
+
+[Encoding / subset]
+encoding=bytes
+match=^t/
+
+END_INI
+
+
+my $tzil = Builder->from_config(
+  { dist_root => 'corpus/dist/DZT' },
+  {
+    add_files => {
+      'source/dist.ini' => $ini
+    },
+  },
+);
+
+$tzil->build;
+
+
+pass;
+
+done_testing;
+


### PR DESCRIPTION
Useful to simplify the 'match' attribute if, for example, you want to match a whole directory, except for a file you know is already encoded.