### PR TITLE
Test::DZil: Load Dist::Zilla::Tester on demand

### DIFF
--- a/lib/Test/DZil.pm
+++ b/lib/Test/DZil.pm
@@ -3,7 +3,6 @@ use warnings;
 package Test::DZil;
 # ABSTRACT: tools for testing Dist::Zilla plugins
 
-use Dist::Zilla::Tester;
 use Params::Util qw(_HASH0);
 use JSON::MaybeXS;
 use Scalar::Util qw(blessed);
@@ -38,6 +37,18 @@ Test::DZil provides routines for writing tests for Dist::Zilla plugins.
 These return class names that subclass L<Dist::Zilla::Dist::Builder> or
 L<Dist::Zilla::Dist::Minter>, respectively, with the L<Dist::Zilla::Tester>
 behavior added.
+
+=cut
+
+sub Builder {
+  require Dist::Zilla::Tester;
+  Dist::Zilla::Tester::builder();
+}
+
+sub Minter {
+  require Dist::Zilla::Tester;
+  Dist::Zilla::Tester::minter();
+}
 
 =func is_filelist
 

--- a/t/tester-demo.t
+++ b/t/tester-demo.t
@@ -21,7 +21,7 @@ ok(
 );
 
 ## SIMPLE TEST WITH DZIL TESTER
-
+require Dist::Zilla::Tester;
 my $tester = Dist::Zilla::Tester->from_config(
   { dist_root => 'corpus/dist/DZT' },
   {


### PR DESCRIPTION
Although most people who load this module will be wanting the builder
functions, there are a couple of utility function in it ( namely,
simple_ini ) that are useful to have, even when not invoking main
Dzil code.

Subsequently, if you are testing an App::Command that doesn't normally
need to load dzil, but does some kind of processing on its own of
dist.ini ( Like authordeps does ), then you must presently pay the moose
price to do so.

This minor change avoids that penalty.

The one downside it does have is some people may have been inherently
dependending on DZT being loaded for them ( as was the test ), but that
is reasonably dodgy in itself.