### PR TITLE
always store 0 or 1 in meta for is_trial flag

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -531,7 +531,7 @@ has _override_is_trial => (
 
 sub _build_is_trial {
     my ($self) = @_;
-    return $self->release_status =~ /\A(?:testing|unstable)\z/;
+    return $self->release_status =~ /\A(?:testing|unstable)\z/ ? 1 : 0;
 }
 
 =attr plugins

--- a/t/plugins/release_status.t
+++ b/t/plugins/release_status.t
@@ -59,11 +59,11 @@ for my $c ( qw/true false/ ) {
 
         is($tzil->release_status, $expect, "release status set from is_trial");
         if ( $is_trial ) {
-            ok($tzil->is_trial, "is_trial is true");
+            is($tzil->is_trial, 1, "is_trial is true, represented as 1");
             like($tzil->archive_filename, qr/-TRIAL/, "-TRIAL in archive filename");
         }
         else {
-            ok(! $tzil->is_trial, "is_trial is not true");
+            is($tzil->is_trial, 0, "is_trial is not true, represented as 0");
             unlike($tzil->archive_filename, qr/-TRIAL/, "-TRIAL not in archive filename");
         }
 


### PR DESCRIPTION
follow-up to the changes made in 5.035 (#438)