### PR TITLE
fallback to version number to set release status

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -177,7 +177,7 @@ sub _build_release_status {
     $status = $this_status;
   }
 
-  return $status || 'stable';
+  return $status || ( $self->version =~ /_/ ? 'testing' : 'stable' );
 }
 
 =attr abstract

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -142,7 +142,8 @@ to using a C<ReleaseStatusProvider>.
 
 Only B<one> C<ReleaseStatusProvider> may be used.
 
-If no providers are used, the release status defaults to 'stable'.
+If no providers are used, the release status defaults to 'stable' unless there
+is an "_" character in the version, in which case, it defaults to 'testing'.
 
 =cut
 

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -137,8 +137,9 @@ Otherwise, the release status will be set from a
 L<ReleaseStatusProvider|Dist::Zilla::Role::ReleaseStatusProvider>, if one
 has been configured.
 
-For backwards compatibility, setting C<is_trial> in F<dist.ini> is equivalent
-to using a C<ReleaseStatusProvider>.
+For backwards compatibility, setting C<is_trial> true in F<dist.ini> is
+equivalent to using a C<ReleaseStatusProvider>.  If C<is_trial> is false,
+it has no effect.
 
 Only B<one> C<ReleaseStatusProvider> may be used.
 
@@ -164,10 +165,10 @@ sub _build_release_status {
   # other ways of setting status must not conflict
   my $status;
 
-  # dist.ini is equivalent to a release provider
-  if ( $self->_has_override_is_trial ) {
-    $status = $self->_override_is_trial ? 'testing' : 'stable';
-  }
+  # dist.ini is equivalent to a release provider if is_trial is true.
+  # If false, though, we want other providers to run or fall back to
+  # the version
+  $status = 'testing' if $self->_override_is_trial;
 
   for my $plugin (@{ $self->plugins_with(-ReleaseStatusProvider) }) {
     next unless defined(my $this_status = $plugin->provide_release_status);
@@ -539,8 +540,9 @@ has is_trial => (
 
 has _override_is_trial => (
   is => 'ro',
+  isa => Bool,
   init_arg => 'is_trial',
-  predicate => '_has_override_is_trial',
+  default => 0,
 );
 
 sub _build_is_trial {

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -532,7 +532,7 @@ has _override_is_trial => (
 
 sub _build_is_trial {
     my ($self) = @_;
-    return $self->release_status =~ /\A(?:testing|unstable)\z/;
+    return $self->release_status =~ /\A(?:testing|unstable)\z/ ? 1 : 0;
 }
 
 =attr plugins

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -147,6 +147,7 @@ is an "_" character in the version, in which case, it defaults to 'testing'.
 
 =cut
 
+# release status must be lazy, after files are gathered
 has release_status => (
   is => 'ro',
   isa => ReleaseStatus,
@@ -158,8 +159,7 @@ sub _build_release_status {
   my ($self) = @_;
 
   # environment variables override completely
-  return $ENV{RELEASE_STATUS} if defined $ENV{RELEASE_STATUS};
-  return 'testing' if $ENV{TRIAL};
+  return $self->_release_status_from_env if $self->_release_status_from_env;
 
   # other ways of setting status must not conflict
   my $status;
@@ -179,6 +179,19 @@ sub _build_release_status {
   }
 
   return $status || ( $self->version =~ /_/ ? 'testing' : 'stable' );
+}
+
+# captures environment variables early during Zilla object construction
+has _release_status_from_env => (
+  is => 'ro',
+  isa => Str,
+  builder => '_build_release_status_from_env',
+);
+
+sub _build_release_status_from_env {
+  my ($self) = @_;
+  return $ENV{RELEASE_STATUS} if $ENV{RELEASE_STATUS};
+  return $ENV{TRIAL} ? 'testing' : '';
 }
 
 =attr abstract

--- a/lib/Dist/Zilla/App/Command/build.pm
+++ b/lib/Dist/Zilla/App/Command/build.pm
@@ -63,10 +63,10 @@ sub execute {
     my $method = $opt->tgz ? 'build_archive' : 'build';
     my $zilla;
     {
+      # isolate changes to RELEASE_STATUS to zilla construction
       local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
       $ENV{RELEASE_STATUS} = 'testing' if $opt->trial;
       $zilla  = $self->zilla;
-      $zilla->release_status; # initialize before running method
     }
     $zilla->$method;
   }

--- a/lib/Dist/Zilla/App/Command/build.pm
+++ b/lib/Dist/Zilla/App/Command/build.pm
@@ -64,7 +64,7 @@ sub execute {
     my $zilla;
     {
       local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
-      $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
+      $ENV{RELEASE_STATUS} = 'testing' if $opt->trial;
       $zilla  = $self->zilla;
       $zilla->release_status; # initialize before running method
     }

--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -30,7 +30,7 @@ sub execute {
   my $zilla;
   {
     local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
-    $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
+    $ENV{RELEASE_STATUS} = 'testing' if $opt->trial;
     $zilla = $self->zilla;
     $zilla->release_status; # initialize before running method
   }

--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -29,10 +29,10 @@ sub execute {
 
   my $zilla;
   {
+    # isolate changes to RELEASE_STATUS to zilla construction
     local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
     $ENV{RELEASE_STATUS} = 'testing' if $opt->trial;
     $zilla = $self->zilla;
-    $zilla->release_status; # initialize before running method
   }
 
   $self->zilla->release;

--- a/t/plugins/release_status.t
+++ b/t/plugins/release_status.t
@@ -132,4 +132,36 @@ subtest "too many providers" => sub {
   );
 };
 
+subtest "from version (stable)" => sub {
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          { version => 1.23 }, 'GatherDir',
+        ),
+      },
+    },
+  );
+
+  $tzil->build;
+  is($tzil->release_status, 'stable', "release status set from version (stable)");
+};
+
+subtest "from version (testing)" => sub {
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          { version => "1.23_45" }, 'GatherDir',
+        ),
+      },
+    },
+  );
+
+  $tzil->build;
+  is($tzil->release_status, 'testing', "release status set from version (testing)");
+};
+
 done_testing;

--- a/t/plugins/release_status.t
+++ b/t/plugins/release_status.t
@@ -59,11 +59,11 @@ for my $c ( qw/true false/ ) {
 
         is($tzil->release_status, $expect, "release status set from is_trial");
         if ( $is_trial ) {
-            ok($tzil->is_trial, "is_trial is true");
+            is($tzil->is_trial, 1, "is_trial is true, represented as 1");
             like($tzil->archive_filename, qr/-TRIAL/, "-TRIAL in archive filename");
         }
         else {
-            ok(! $tzil->is_trial, "is_trial is not true");
+            is($tzil->is_trial, 0, "is_trial is not true, represented as 0");
             unlike($tzil->archive_filename, qr/-TRIAL/, "-TRIAL not in archive filename");
         }
 


### PR DESCRIPTION
The change to support release provider plugins accidentally dropped
support for marking distributions as 'testing' based on the presence of
an underscore in the version number.  This commit restores that
behavior.

Fixes #445.


