### PR TITLE
help fix #445 - don't force 'stable' relstatus

### DIFF
--- a/lib/Dist/Zilla/App/Command/build.pm
+++ b/lib/Dist/Zilla/App/Command/build.pm
@@ -64,7 +64,7 @@ sub execute {
     my $zilla;
     {
       local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
-      $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
+      $ENV{RELEASE_STATUS} = 'testing' if $opt->trial;
       $zilla  = $self->zilla;
       $zilla->release_status; # initialize before running method
     }

--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -30,7 +30,7 @@ sub execute {
   my $zilla;
   {
     local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
-    $ENV{RELEASE_STATUS} ||= $opt->trial ? "testing" : "stable";
+    $ENV{RELEASE_STATUS} = 'testing' if $opt->trial;
     $zilla = $self->zilla;
     $zilla->release_status; # initialize before running method
   }


### PR DESCRIPTION
build&command used to force $ENV{RELEASE_STATUS} to 'stable' if --trial
was not passed on the command line, completely disabling the
ReleaseStatusProvider plugins