### PR TITLE
tighten up the regex that extracts local packages in AutoPrereqs

### DIFF
--- a/corpus/dist/AutoPrereqs/lib/DZPA/Main.pm
+++ b/corpus/dist/AutoPrereqs/lib/DZPA/Main.pm
@@ -23,6 +23,9 @@ use parent qw{ DZPA::Base::parent2 DZPA::Base::parent3 };
 # DZPA::Skip should be trimmed
 use DZPA::Skip::Blah;
 
+# and this comment should not cause a package to be trimmed:
+# package foobar DZPA::Role
+
 # require in a module
 require DZPA::ModRequire;
 
@@ -54,3 +57,6 @@ this pod should not be taken in to account, with:
 use fake;
 require blah;
 with 'fubar';
+
+nor should this statement here, but that is still a TODO!
+pack age strict;  XXX remove this space

--- a/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
@@ -170,7 +170,9 @@ sub register_prereqs {
       s{\.pm$}{} for @this_thing;
       s{/}{::}g for @this_thing;
 
-      push @this_thing, $file->content =~ /package\s+([^\s;]+)/g;
+      # this is a bunk heuristic and can still capture strings from pod - the
+      # proper thing to do is grab all packages from Module::Metadata
+      push @this_thing, $file->content =~ /^[^#]*?(?:^|\s)package\s+([^\s;#]+)/mg;
       push @modules, List::MoreUtils::uniq @this_thing;
 
       # parse a file, and merge with existing prereqs
@@ -183,6 +185,7 @@ sub register_prereqs {
     }
 
     # remove prereqs shipped with current dist
+    $self->log_debug([ 'excluding local packages: %s', sub { join(', ', List::MoreUtils::uniq @modules) } ]);
     $req->clear_requirement($_) for @modules;
 
     $req->clear_requirement($_) for qw(Config Errno); # never indexed

--- a/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
@@ -197,7 +197,7 @@ sub register_prereqs {
     $self->log_debug([ 'excluding local packages: %s', sub { join(', ', List::MoreUtils::uniq @modules) } ]);
     $req->clear_requirement($_) for @modules;
 
-    $req->clear_requirement($_) for qw(Config Errno); # never indexed
+    $req->clear_requirement($_) for qw(Config DB Errno NEXT Pod::Functions); # never indexed
 
     # we're done, return what we've found
     my %got = %{ $req->as_string_hash };


### PR DESCRIPTION
Skip all comments, words with sigils.

However, we still extract content from pod. The only real remedy for that is to use Module::Metadata. To make that more efficient, I recommend pulling Dist::Zilla::Role::ModuleMetadata into core (which caches the parsed document, just like the PPI role does, for sharing between all plugins that are interested in its data. I currently use three that do this:

https://metacpan.org/requires/distribution/Dist-Zilla-Role-ModuleMetadata?sort=[[2,1]]&size=100