### PR TITLE
warn the user if passing version ranges to EUMM, which are treated as 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ perl:
   - 5.10
 install:
   - cpanm -nq Devel::Cover::Report::Coveralls
-  - cpanm Dist::Zilla
+  - cpanm JSON::PP Dist::Zilla
   - dzil authordeps --missing | cpanm || { cat ~/.cpanm/build.log ; false ; }
   - dzil listdeps --author --missing | cpanm || { cat ~/.cpanm/build.log ; false ; }
 script:

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+          - issue a warning when version ranges are passed through to
+            ExtUtils::MakeMaker, which cannot parse them and treats them as
+            '0' (see https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/215)
 
 5.036     2015-05-02 11:08:51-04:00 America/New_York
         - BUGFIX: detection of trial status via underscore in version was

--- a/lib/Dist/Zilla/Plugin/MakeMaker.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker.pm
@@ -203,8 +203,9 @@ sub write_makefile_args {
     );
   };
 
-  my $build_prereq = $prereqs_dump->(qw(build requires));
-  my $test_prereq = $prereqs_dump->(qw(test requires));
+  my %require_prereqs = map {
+    $_ => $prereqs_dump->($_, 'requires');
+  } qw(configure build test runtime);
 
   my %write_makefile_args = (
     DISTNAME  => $self->zilla->name,
@@ -215,10 +216,10 @@ sub write_makefile_args {
     LICENSE   => $self->zilla->license->meta_yml_name,
     EXE_FILES => [ @exe_files ],
 
-    CONFIGURE_REQUIRES => $prereqs_dump->(qw(configure requires)),
-    keys %$build_prereq ? ( BUILD_REQUIRES => $build_prereq ) : (),
-    keys %$test_prereq ? ( TEST_REQUIRES => $test_prereq ) : (),
-    PREREQ_PM          => $prereqs_dump->(qw(runtime   requires)),
+    CONFIGURE_REQUIRES => $require_prereqs{configure},
+    keys %{ $require_prereqs{build} } ? ( BUILD_REQUIRES => $require_prereqs{build} ) : (),
+    keys %{ $require_prereqs{test} } ? ( TEST_REQUIRES => $require_prereqs{test} ) : (),
+    PREREQ_PM          => $require_prereqs{runtime},
 
     test => { TESTS => join q{ }, sort keys %test_dirs },
   );


### PR DESCRIPTION
addresses #442. See also https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/215

I've released the same change in [MakeMaker::Awesome] version 0.34.
