### PR TITLE
disregard PAUSE credentials set via dist.ini

### DIFF
--- a/lib/Dist/Zilla/Plugin/UploadToCPAN.pm
+++ b/lib/Dist/Zilla/Plugin/UploadToCPAN.pm
@@ -77,16 +77,17 @@ sub mvp_aliases {
 
 =attr username
 
-This option supplies the user's PAUSE username.  If not supplied, it will be
-looked for in the user's PAUSE configuration.
+This option supplies the user's PAUSE username.  It cannot be provided via
+F<dist.ini>.  It will be looked for in the user's PAUSE configuration; if not
+found, the user will be prompted.
 
 =cut
 
 has username => (
   is   => 'ro',
   isa  => 'Str',
+  init_arg => undef,
   lazy => 1,
-  required => 1,
   default  => sub {
     my ($self) = @_;
     return $self->_credential('username')
@@ -97,16 +98,17 @@ has username => (
 
 =attr password
 
-This option supplies the user's PAUSE password.  If not supplied, it will be
-looked for in the user's PAUSE configuration.
+This option supplies the user's PAUSE password.  It cannot be provided via
+F<dist.ini>.  It will be looked for in the user's PAUSE configuration; if not
+found, the user will be prompted.
 
 =cut
 
 has password => (
   is   => 'ro',
   isa  => 'Str',
+  init_arg => undef,
   lazy => 1,
-  required => 1,
   default  => sub {
     my ($self) = @_;
     return $self->_credential('password')

--- a/t/plugins/uploadtocpan.t
+++ b/t/plugins/uploadtocpan.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More 0.88 tests => 16;
+use Test::More 0.88 tests => 17;
 
 use File::Spec ();
 use Test::DZil qw(Builder simple_ini);
@@ -138,4 +138,21 @@ my %safety_first = (qw(upload_uri http://bogus.example.com/do/not/upload/),
     !grep({ /fake release happen/i } @$msgs),
     "no release without password"
   );
+}
+
+# Config from dist.ini
+{
+  my $tzil = build_tzil(
+    'FakeRelease',
+    [ UploadToCPAN => {
+        %safety_first,
+        username => 'me',
+        password => 'ohhai',
+      }
+    ],
+  );
+
+  like( exception { $tzil->release },
+        qr/You need to supply a username/,
+        "username and password set in dist.ini is ignored");
 }


### PR DESCRIPTION
as discussed on #toolchain.