### PR TITLE
Fix warning on Perl 5.8.8 that causes test failure in file.t

### DIFF
--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -274,7 +274,9 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
 
     local @INC = map {; ref($_) ? $_ : File::Spec->rel2abs($_) } @INC;
 
-    local $ENV{DZIL_GLOBAL_CONFIG_ROOT} = $tester_arg->{global_config_root};
+    local $ENV{DZIL_GLOBAL_CONFIG_ROOT};
+    $ENV{DZIL_GLOBAL_CONFIG_ROOT} = $tester_arg->{global_config_root}
+      if defined $ENV{DZIL_GLOBAL_CONFIG_ROOT};
 
     my $global_stashes = $self->_setup_global_config(
       $tester_arg->{global_config_root},

--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -160,7 +160,9 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
 
     local @INC = map {; ref($_) ? $_ : File::Spec->rel2abs($_) } @INC;
 
-    local $ENV{DZIL_GLOBAL_CONFIG_ROOT} = $tester_arg->{global_config_root};
+    local $ENV{DZIL_GLOBAL_CONFIG_ROOT};
+    $ENV{DZIL_GLOBAL_CONFIG_ROOT} = $tester_arg->{global_config_root}
+      if defined $ENV{DZIL_GLOBAL_CONFIG_ROOT};
 
     my $zilla = $self->$orig($arg);
 


### PR DESCRIPTION
Weird but true: on Perl 5.8.8, this gives a warning:

 perl -e 'use warnings; local $ENV{FOO} = undef' ;
 Use of uninitialized value in scalar assignment at -e line 1.

Only seems to happen for `%ENV`.  This warning is not generated on 5.8.9 or 5.10.0.  Because t/file.t is using `Test::FailWarnings` this causes it to fail.  A more elegant refinement of the code might be more appropriate or requiring Perl 5.8.9.