### PR TITLE
omit configure-requires prerequisites from merged_requires

### DIFF
--- a/Changes
+++ b/Changes
@@ -27,6 +27,8 @@ Revision history for {{$dist->name}}
         - improve errors when PPI failes to parse (thanks, Nick Tonkin)
         - sort list of executable files in Makefile.PL, for deterministic
           builds (thanks, Karen Etheridge)
+        - omit configure-requires prerequisites from [MakeMaker]'s fallback
+          prerequisites (used by older ExtUtils::MakeMaker)
 
 5.037     2015-06-04 21:46:38-04:00 America/New_York
         - issue a warning when version ranges are passed through to

--- a/lib/Dist/Zilla/Prereqs.pm
+++ b/lib/Dist/Zilla/Prereqs.pm
@@ -49,6 +49,8 @@ has cpan_meta_prereqs => (
 
 # storing this is sort of gross, but MakeMaker winds up needing the same data
 # anyway. -- xdg, 2013-10-22
+# This does *not* contain configure requires, as MakeMaker explicitly should
+# not have it in its fallback prereqs.
 has merged_requires => (
   is => 'ro',
   isa => 'CPAN::Meta::Requirements',
@@ -122,11 +124,6 @@ sub sync_runtime_build_test_requires {
       );
     }
   }
-
-  # and add configure requires for other consumers expecting this to be a full
-  # merge across all phases required by users
-  $self->merged_requires->add_requirements(
-      $self->requirements_for('configure', 'requires'));
 
   return;
 }

--- a/t/plugins/makemaker.t
+++ b/t/plugins/makemaker.t
@@ -73,7 +73,9 @@ use Test::DZil;
           'GatherDir',
           'MakeMaker',
           [ Prereqs => { perl => '5.8.1' } ],
-          [ Prereqs => ConfigureRequires => { 'Builder::Bob' => 0 } ],
+          [ Prereqs => BuildRequires => { 'Builder::Bob' => 0 } ],
+          [ Prereqs => TestRequires => { 'Tester::Bob' => 0 } ],
+          [ Prereqs => RuntimeRequires => { 'Runner::Bob' => 0 } ],
         ),
       },
     },
@@ -86,7 +88,10 @@ use Test::DZil;
   like($content, qr/^use 5\.008001;\s*$/m, "normalized the perl version needed");
 
   $content =~ m'^my %FallbackPrereqs = \(\n([^;]+)^\);$'mg;
-  like($1, qr'"Builder::Bob" => ', 'configure-requires prereqs made it into %FallbackPrereqs');
+
+  like($1, qr'"Builder::Bob" => ', 'build-requires prereqs made it into %FallbackPrereqs');
+  like($1, qr'"Tester::Bob" => ', 'test-requires prereqs made it into %FallbackPrereqs');
+  like($1, qr'"Runner::Bob" => ', 'runtime-requires prereqs made it into %FallbackPrereqs');
 }
 
 {


### PR DESCRIPTION
This data went into the fallback prereqs used by [MakeMaker], but it's already
too late to fulfill configure prereqs that weren't already in META.

(This is intended to make the ::Fallback behaviour better on older toolchains. cc @ribasushi, @haarg