### PR TITLE
[PkgVersion]: add safe $VERSION when version has an underscore

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - [PkgVersion] adds "$VERSION = eval $VERSION" when version contains
+          an underscore
 
 5.039     2015-08-10 09:03:08-04:00 America/New_York
         - update required version of MooseX::Role::Parameterized; older

--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -236,11 +236,13 @@ sub munge_perl {
     }
 
     $perl = $blank ? "$perl\n" : "\n$perl";
+
+    (my $clean_version = $version) =~ tr/_//d;
     $perl .= (
       $self->use_our
-        ? "\n\$VERSION\x20=\x20eval\x20\$VERSION;"
-        : "\n\$$package\::VERSION\x20=\x20eval\x20\$$package\::VERSION;"
-      ) if $version =~ /_/ and scalar($version =~ /\./g) <= 1;
+        ? "\n\$VERSION\x20=\x20'$clean_version';"
+        : "\n\$$package\::VERSION\x20=\x20'$clean_version';"
+      ) if $version ne $clean_version;
 
     # Why can't I use PPI::Token::Unknown? -- rjbs, 2014-01-11
     my $bogus_token = PPI::Token::Comment->new($perl);

--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -236,6 +236,11 @@ sub munge_perl {
     }
 
     $perl = $blank ? "$perl\n" : "\n$perl";
+    $perl .= (
+      $self->use_our
+        ? "\n\$VERSION\x20=\x20eval\x20\$VERSION;"
+        : "\n\$$package\::VERSION\x20=\x20eval\x20\$$package\::VERSION;"
+      ) if $version =~ /_/ and scalar($version =~ /\./g) <= 1;
 
     # Why can't I use PPI::Token::Unknown? -- rjbs, 2014-01-11
     my $bogus_token = PPI::Token::Comment->new($perl);

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -448,13 +448,13 @@ foreach my $use_our (0, 1) {
       ? <<'MODULE'
 package DZT::Sample;
 { our $VERSION = '0.004_002'; } # TRIAL
-$VERSION = eval $VERSION;
+$VERSION = '0.004002';
 1;
 MODULE
       : <<'MODULE'
 package DZT::Sample;
 $DZT::Sample::VERSION = '0.004_002'; # TRIAL
-$DZT::Sample::VERSION = eval $DZT::Sample::VERSION;
+$DZT::Sample::VERSION = '0.004002';
 1;
 MODULE
     ,


### PR DESCRIPTION
Adds $VERSION = eval $VERSION; when using an underscore trial version; it turns out that Dist::Zilla is quite happy to deal with underscore versions everywhere; we just usually don't :)