### PR TITLE
Keep build output sorted

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,8 @@ Revision history for {{$dist->name}}
         - better errors when a global config package isn't available (thanks,
           Karen Etheridge)
         - added the "ignore" option to [Encoding] (thanks, Yanick Champoux)
+        - sort list of executable files in Makefile.PL, for deterministic
+          builds
 
 5.037     2015-06-04 21:46:38-04:00 America/New_York
         - issue a warning when version ranges are passed through to

--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -153,8 +153,8 @@ around dump_config => sub {
   my $config = $self->$orig;
 
   $config->{+__PACKAGE__} = {
-    map { $_ => $self->$_ }
-      qw(root prefix include_dotfiles follow_symlinks exclude_filename exclude_match prune_directory),
+    (map { $_ => $self->$_ } qw(root prefix include_dotfiles follow_symlinks)),
+    (map { $_ => [ sort @{ $self->$_ } ] } qw(exclude_filename exclude_match prune_directory)),
   };
 
   return $config;

--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -153,7 +153,8 @@ around dump_config => sub {
   my $config = $self->$orig;
 
   $config->{+__PACKAGE__} = {
-    (map { $_ => $self->$_ } qw(root prefix include_dotfiles follow_symlinks)),
+    (map { $_ => $self->$_ } qw(root prefix)),
+    (map { $_ => $self->$_ ? 1 : 0 } qw(include_dotfiles follow_symlinks)),
     (map { $_ => [ sort @{ $self->$_ } ] } qw(exclude_filename exclude_match prune_directory)),
   };
 

--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -153,7 +153,9 @@ around dump_config => sub {
   my $config = $self->$orig;
 
   $config->{+__PACKAGE__} = {
-    (map { $_ => $self->$_ } qw(root prefix)),
+    prefix => $self->prefix,
+    # only report relative to dist root to avoid leaking private info
+    root => path($self->root)->relative($self->zilla->root),
     (map { $_ => $self->$_ ? 1 : 0 } qw(include_dotfiles follow_symlinks)),
     (map { $_ => [ sort @{ $self->$_ } ] } qw(exclude_filename exclude_match prune_directory)),
   };

--- a/lib/Dist/Zilla/Plugin/MakeMaker.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker.pm
@@ -226,7 +226,7 @@ sub write_makefile_args {
     ABSTRACT  => $self->zilla->abstract,
     VERSION   => $self->zilla->version,
     LICENSE   => $self->zilla->license->meta_yml_name,
-    EXE_FILES => [ @exe_files ],
+    @exe_files ? ( EXE_FILES => [ sort @exe_files ] ) : (),
 
     CONFIGURE_REQUIRES => $require_prereqs{configure},
     keys %{ $require_prereqs{build} } ? ( BUILD_REQUIRES => $require_prereqs{build} ) : (),

--- a/lib/Dist/Zilla/Plugin/RemovePrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/RemovePrereqs.pm
@@ -45,7 +45,7 @@ around dump_config => sub {
   my $config = $self->$orig;
 
   my $this_config = {
-    modules_to_remove  => $self->modules_to_remove,
+    modules_to_remove  => [ sort @{ $self->modules_to_remove } ],
   };
 
   $config->{'' . __PACKAGE__} = $this_config;

--- a/t/plugins/installdirs.t
+++ b/t/plugins/installdirs.t
@@ -247,7 +247,7 @@ test_this(
 
     is_deeply(
       $makemaker->__write_makefile_args->{EXE_FILES},
-      [],
+      undef,
       "not going to install execs",
     );
   },
@@ -261,7 +261,7 @@ test_this(
     my $makemaker = $tzil->plugin_named('MakeMaker');
     is_deeply(
       $makemaker->__write_makefile_args->{EXE_FILES},
-      [],
+      undef,
       "files in ./bin, but no ExecDir, not going to install execs",
     );
   },

--- a/t/plugins/makemaker.t
+++ b/t/plugins/makemaker.t
@@ -38,7 +38,6 @@ use Test::DZil;
     AUTHOR   => 'E. Xavier Ample <example@example.org>',
     LICENSE  => 'perl',
     MIN_PERL_VERSION => '5.010',
-    EXE_FILES => [],
     test => { TESTS => 't/*.t' },
 
     PREREQ_PM          => {
@@ -55,7 +54,6 @@ use Test::DZil;
     CONFIGURE_REQUIRES => {
       'ExtUtils::MakeMaker' => '0'
     },
-    EXE_FILES => [],
     test => { TESTS => 't/*.t' },
   );
 


### PR DESCRIPTION
sorts the dumping of various arrayrefs in Makefile.PL and metadata, for greater consistency between builds. This keeps ad-hoc diffs smaller, and helps distribution packagers.