### PR TITLE
Include file name when croaking in ppi_document_for_file()

### DIFF
--- a/lib/Dist/Zilla/Role/PPI.pm
+++ b/lib/Dist/Zilla/Role/PPI.pm
@@ -40,7 +40,7 @@ sub ppi_document_for_file {
 
   require PPI::Document;
   my $document = PPI::Document->new(\$encoded_content)
-    or Carp::croak(PPI::Document->errstr);
+    or Carp::croak(PPI::Document->errstr . ' while processing file ' . $file->name);
 
   return ($CACHE{$md5} = $document)->clone;
 }


### PR DESCRIPTION
Include the name of the file we are processing when we croak with PPI::Document->errstr in ppi_document_for_file() ...

For example, when building with [PkgVersion] using a FileFinder with the default settings of InstallModules and ExecFiles, we croak on bin/foo.tar.gz, but the only error message printed is:

Encountered unexpected character '31' at /perl/lib/Dist/Zilla/Plugin/PkgVersion.pm line 150.

This change makes the error message:

Encountered unexpected character '31' while processing file bin/foo.tar.gz at /perl/lib/Dist/Zilla/Plugin/PkgVersion.pm line 150.