### PR TITLE
PkgVersion can now use the first empty line it finds

### DIFF
--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -167,7 +167,7 @@ sub munge_perl {
   my %seen_pkg;
 
   my $munged = 0;
-  for my $stmt (@$package_stmts) {
+  while (my $stmt = shift @$package_stmts) {
     my $package = $stmt->namespace;
     if ($seen_pkg{ $package }++) {
       $self->log([ 'skipping package re-declaration for %s', $package ]);
@@ -202,6 +202,10 @@ sub munge_perl {
       $file->name,
     ]);
 
+    my $last_usable_line_number = do {
+        my ($next_stmt) = @$package_stmts;
+        $next_stmt ? $next_stmt->line_number : undef;
+    };
     my $blank;
 
     {
@@ -221,6 +225,9 @@ sub munge_perl {
           $blank = $find->[0];
           last;
         }
+
+        last if $last_usable_line_number &&
+            $find->[0]->line_number >= $last_usable_line_number;
 
         $curr = $find->[0];
       }

--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -215,18 +215,14 @@ sub munge_perl {
           return $line > $curr_line_number ? undef : $line == $curr_line_number;
         });
 
-        last unless $find and @$find == 1;
+        last unless $find;
 
-        if ($find->[0]->isa('PPI::Token::Comment')) {
-          $curr = $find->[0];
-          next;
-        }
-
-        if ("$find->[0]" =~ /\A\s*\z/) {
+        if (@$find == 1 and "$find->[0]" =~ /\A\s*\z/) {
           $blank = $find->[0];
+          last;
         }
 
-        last;
+        $curr = $find->[0];
       }
     }
 

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -137,16 +137,28 @@ my $pod_no_pkg = '
 
 my $pkg_with_strict = '
 package DZT::WithStrict;
-use strict;
+# comment
+  use strict;
+# other comment
 
+sub foo {
+
+    return 1;
+
+}
 1;
 ';
 
 my $pkg_pathological = '
 package DZT::Pathological;
+# comment
 use strict;
 package DZT::Pathological2;
 use strict;
+sub foo {
+
+    return 1;
+}
 1;
 ';
 
@@ -334,7 +346,11 @@ unlike(
 my $dzt_with_strict = $tzil->slurp_file('build/lib/DZT/WithStrict.pm');
 like(
   $dzt_with_strict,
-  qr{^use strict;\s*^\$DZT::WithStrict::VERSION = '0\.001';\s*$}m,
+  qr{
+     ^\s* use \s+ strict; \s*
+     ^\# .*? $ \s*
+     ^\$DZT::WithStrict::VERSION \s+ = \s+ '0\.001';\s*
+  }mx,
   "version inserted in the first empty line"
 );
 
@@ -344,6 +360,7 @@ like(
   qr{
      ^package \s+ DZT::Pathological; \s*
      ^\$DZT::Pathological::VERSION \s+ = \s+ '0\.001'; \s*
+     ^\# .*? $ \s*
      ^use \s+ strict; \s*
      ^package \s+ DZT::Pathological2; \s*
      ^\$DZT::Pathological2::VERSION \s+ = \s+ '0\.001'; \s*

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -135,6 +135,13 @@ my $pod_no_pkg = '
 =cut
 ';
 
+my $pkg_with_strict = '
+package DZT::WithStrict;
+use strict;
+
+1;
+';
+
 my $tzil = Builder->from_config(
   { dist_root => 'corpus/dist/DZT' },
   {
@@ -154,6 +161,7 @@ my $tzil = Builder->from_config(
       'source/lib/DZT/HideMe.pm' => $hide_me_comment,
       'source/lib/DZT/PodWithPackage.pm' => $pod_with_pkg,
       'source/lib/DZT/PodNoPackage.pm' => $pod_no_pkg,
+      'source/lib/DZT/WithStrict.pm' => $pkg_with_strict,
       'source/bin/script_pkg.pl' => $script_pkg,
       'source/bin/script_ver.pl' => $script_pkg . "our \$VERSION = 1.234;\n",
       'source/bin/script.pl'     => $script,
@@ -312,6 +320,13 @@ unlike(
   $dzt_podnopackage,
   qr{VERSION},
   "no version for pod files with no package declaration"
+);
+
+my $dzt_with_strict = $tzil->slurp_file('build/lib/DZT/WithStrict.pm');
+like(
+  $dzt_with_strict,
+  qr{^use strict;\s*^\$DZT::WithStrict::VERSION = '0\.001';\s*$}m,
+  "version inserted in the first empty line"
 );
 
 {

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -142,6 +142,14 @@ use strict;
 1;
 ';
 
+my $pkg_pathological = '
+package DZT::Pathological;
+use strict;
+package DZT::Pathological2;
+use strict;
+1;
+';
+
 my $tzil = Builder->from_config(
   { dist_root => 'corpus/dist/DZT' },
   {
@@ -162,6 +170,7 @@ my $tzil = Builder->from_config(
       'source/lib/DZT/PodWithPackage.pm' => $pod_with_pkg,
       'source/lib/DZT/PodNoPackage.pm' => $pod_no_pkg,
       'source/lib/DZT/WithStrict.pm' => $pkg_with_strict,
+      'source/lib/DZT/Pathological.pm' => $pkg_pathological,
       'source/bin/script_pkg.pl' => $script_pkg,
       'source/bin/script_ver.pl' => $script_pkg . "our \$VERSION = 1.234;\n",
       'source/bin/script.pl'     => $script,
@@ -327,6 +336,20 @@ like(
   $dzt_with_strict,
   qr{^use strict;\s*^\$DZT::WithStrict::VERSION = '0\.001';\s*$}m,
   "version inserted in the first empty line"
+);
+
+my $dzt_pathological = $tzil->slurp_file('build/lib/DZT/Pathological.pm');
+like(
+  $dzt_pathological,
+  qr{
+     ^package \s+ DZT::Pathological; \s*
+     ^\$DZT::Pathological::VERSION \s+ = \s+ '0\.001'; \s*
+     ^use \s+ strict; \s*
+     ^package \s+ DZT::Pathological2; \s*
+     ^\$DZT::Pathological2::VERSION \s+ = \s+ '0\.001'; \s*
+     ^use \s+ strict; \s*
+  }xm,
+  "version inserted after 'package' if no empty line"
 );
 
 {


### PR DESCRIPTION
Normally, `PkgVersion` inserts the version assignment just after the package declaration. This makes `Perl::Critic::Policy::TestingAndDebugging::RequireUseStrict` unhappy, because there's now code before `use strict`.

With this change, `PkgVersion` uses the first empty line it sees (before the next package declaration, if any). This not only avoids perlcritic problems, it also reduces the probability of line insertion, since most people will put a new line after all the `use`s.
