### PR TITLE
drop the redundant -TRIAL in archive_filename if the version contains an underscore

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - the distribution tarball name no longer includes -TRIAL if the
+          version contains an underscore
 
 5.039     2015-08-10 09:03:08-04:00 America/New_York
         - update required version of MooseX::Role::Parameterized; older

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -523,8 +523,7 @@ has root => (
 =attr is_trial
 
 This attribute tells us whether or not the dist will be a trial release,
-i.e. whether it has C<release_status> 'testing' or 'unstable' and will
-have '-TRIAL' in the tarball name.
+i.e. whether it has C<release_status> 'testing' or 'unstable'.
 
 Do not set this directly, it will be derived from C<release_status>.
 

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -444,8 +444,9 @@ sub dist_basename {
   my $tarball = $zilla->archive_filename;
 
 This method will return the filename (e.g. C<Dist-Name-1.01.tar.gz>)
-of the tarball of this dist.  It will include C<-TRIAL> if building a
-trial dist.  The tarball might not exist.
+of the tarball of this distribution.  It will include C<-TRIAL> if building a
+trial distribution, unless the version contains an underscore.  The tarball
+might not exist.
 
 =cut
 
@@ -453,7 +454,7 @@ sub archive_filename {
   my ($self) = @_;
   return join(q{},
     $self->dist_basename,
-    ( $self->is_trial ? '-TRIAL' : '' ),
+    ( $self->is_trial && $self->version !~ /_/ ? '-TRIAL' : '' ),
     '.tar.gz'
   );
 }

--- a/t/plugins/release_status.t
+++ b/t/plugins/release_status.t
@@ -146,6 +146,9 @@ subtest "from version (stable)" => sub {
 
   $tzil->build;
   is($tzil->release_status, 'stable', "release status set from version (stable)");
+  ok(!$tzil->is_trial, "is_trial is false");
+  unlike($tzil->archive_filename, qr/-TRIAL/, "no -TRIAL in archive filename");
+
 };
 
 subtest "from version (testing)" => sub {
@@ -162,6 +165,8 @@ subtest "from version (testing)" => sub {
 
   $tzil->build;
   is($tzil->release_status, 'testing', "release status set from version (testing)");
+  ok($tzil->is_trial, "is_trial is true");
+  unlike($tzil->archive_filename, qr/-TRIAL/, "no -TRIAL in archive filename");
 };
 
 done_testing;


### PR DESCRIPTION
resolves #475.