### PR TITLE
(merge-ready) Always create a symlink to the latest build

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - all builds now result in a .build/latest symlink
 
 6.012     2018-04-21 10:20:21+02:00 Europe/Oslo
         - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -674,16 +674,16 @@ sub _create_build_symlinks {
     $latest   = path( $symlink_root, 'latest'   );
     if( -l $previous ) {
       $previous->remove
-        or $self->log([ 'cannot remove old %s/previous link', $symlink_root ]);
+        or $self->log([ 'cannot remove old %s/previous link', "$symlink_root" ]);
     }
     if( -l $latest ) {
       rename $latest, $previous
-        or $self->log([ 'cannot move %s/latest link to .build/previous', $symlink_root ]);
+        or $self->log([ 'cannot move %s/latest link to .build/previous', "$symlink_root" ]);
     }
 
     my $link_dest = path($build_target)->relative(path($latest)->parent);
     symlink $link_dest->stringify, $latest
-      or $self->log([ 'cannot create link %s/latest', $symlink_root ]);
+      or $self->log([ 'cannot create link %s/latest', "$symlink_root" ]);
   }
 
   return ($latest, $previous);

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -670,7 +670,7 @@ sub ensure_built_in_tmpdir {
       or $self->log('cannot create link .build/latest');
   }
 
-  $self->ensure_built_in($target);
+  $self->build_in($target);
 
   return ($target, $latest, $previous);
 }

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -376,6 +376,8 @@ sub build_in {
   $_->after_build({ build_root => $build_root })
     for @{ $self->plugins_with(-AfterBuild) };
 
+  $self->_create_build_symlinks(path('.build'), $build_root);
+
   $self->built_in($build_root);
 }
 
@@ -651,28 +653,40 @@ sub ensure_built_in_tmpdir {
   my $target = path( File::Temp::tempdir(DIR => $build_root) );
   $self->log("building distribution under $target for installation");
 
+  my ($latest, $previous) = $self->_create_build_symlinks($build_root, $target);
+
+  $self->build_in($target);
+
+  return ($target, $latest, $previous);
+}
+
+sub _create_build_symlinks {
+  my ($self, $symlink_root, $build_target) = @_;
+
+  $symlink_root->mkpath unless -d $symlink_root;
+
   my $os_has_symlinks = eval { symlink("",""); 1 };
   my $previous;
   my $latest;
 
   if( $os_has_symlinks ) {
-    $previous = path( $build_root, 'previous' );
-    $latest   = path( $build_root, 'latest'   );
+    $previous = path( $symlink_root, 'previous' );
+    $latest   = path( $symlink_root, 'latest'   );
     if( -l $previous ) {
       $previous->remove
-        or $self->log("cannot remove old .build/previous link");
+        or $self->log([ 'cannot remove old %s/previous link', $symlink_root ]);
     }
     if( -l $latest ) {
       rename $latest, $previous
-        or $self->log("cannot move .build/latest link to .build/previous");
+        or $self->log([ 'cannot move %s/latest link to .build/previous', $symlink_root ]);
     }
-    symlink $target->basename, $latest
-      or $self->log('cannot create link .build/latest');
+
+    my $link_dest = path($build_target)->relative(path($latest)->parent);
+    symlink $link_dest->stringify, $latest
+      or $self->log([ 'cannot create link %s/latest', $symlink_root ]);
   }
 
-  $self->build_in($target);
-
-  return ($target, $latest, $previous);
+  return ($latest, $previous);
 }
 
 =method install


### PR DESCRIPTION
This is incomplete, but I'm pushing it up now so I can ask questions.

What I'm going for is this: I want to create a `.build/latest` symlink no matter what type of build is run - even `dzil build`.

I've split the make-symlink logic out into its own private sub, and calling it in one extra place -- at the end of `build_in()` itself. However this is bad because now sometimes the symlink logic will be done twice, so the `previous` symlink will be lost.  I started moving this out and instead calling the symlink logic in the callers of `build_in()`, but that ends up duplicating information (i.e. the `.build` dir name). Alternatively, `build_in()` could be the one location where the symlink logic is called, but that requires build_in to have a return value that it currently doesn't have.

This could all be made a little cleaner if this bit of code was removed everywhere: `$latest->remove if $latest;` (as then we don't need to return the `$latest` symlink)...

thoughts? I'll keep trying to muddle ahead though...
