### PR TITLE
Distribution name is passed to Software::License constructor as "program" argument.

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -383,8 +383,9 @@ sub _build_license {
   Class::Load::load_class($license_class);
 
   my $license = $license_class->new({
-    holder => $self->_copyright_holder,
-    year   => $self->_copyright_year,
+    holder  => $self->_copyright_holder,
+    year    => $self->_copyright_year,
+    program => $self->name,
   });
 
   $self->_clear_license_class;


### PR DESCRIPTION
Rationale: Some license notices may utilize software name. For example, FSF recommends:

> For programs that are more than one file, it is better to replace “this program” with the name of the program, and begin the statement with a line saying “This file is part of NAME”.

Software::License constructor just saves all the arguments, so a new argument does not hurt existing licenses.

I run `dzil build`, `dzil test`, `dzil xtest` locally on my system. All tests pass, no failures (I had to add dummy record to `Changes` file to let xtests pass).

BTW, if `program` is not suitable for argument name, please suggest replacement.
