### PR TITLE
Use absolute paths rather than relative ones when gathering files

### DIFF
--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -173,7 +173,7 @@ sub gather_files {
   my $repo_root = $self->zilla->root;
   my $root = "" . $self->root;
   $root =~ s{^~([\\/])}{require File::HomeDir; File::HomeDir::->my_home . $1}e;
-  $root = path($repo_root)->child($root)->stringify if path($root)->is_relative;
+  $root = path($root)->absolute($repo_root)->stringify if path($root)->is_relative;
 
   my $prune_regex = qr/\000/;
   $prune_regex = qr/$prune_regex|$_/


### PR DESCRIPTION
This fixes issues when using [ShareDir::Tarball] on OSX (where the sharedir is
inflated into /tmp and files are being gathered from it).

We can run into issues when the repo root is underneath a symlink at a
different depth than the real path -- e.g. OSX's TMPDIR defaults to /tmp,
which is a symlink to private/tmp (and /var symlinks to /private/var, so
/private/var/tmp is the final canonical location).

When we make /tmp/whargarbl/source/foo into a link relative to the repo root
(/tmp/whargarbl/source), we end up with ../../../private/tmp/whargarbl/source,
which does not exist.

Arguably this is actually an issue with File::Spec::abs2rel.