### PR TITLE
Set default jobs to 1 otherwise strange results can happen

### DIFF
--- a/lib/Dist/Zilla/App/Command/test.pm
+++ b/lib/Dist/Zilla/App/Command/test.pm
@@ -34,7 +34,7 @@ sub opt_spec {
   [ 'author!' => 'enables the AUTHOR_TESTING env variable (default behavior)', { default => 1 } ],
   [ 'all' => 'enables the RELEASE_TESTING, AUTOMATED_TESTING and AUTHOR_TESTING env variables', { default => 0 } ],
   [ 'keep-build-dir|keep' => 'keep the build directory even after a success' ],
-  [ 'jobs|j=i' => 'number of parallel test jobs to run' ],
+  [ 'jobs|j=i' => 'number of parallel test jobs to run', { default => 1 } ],
   [ 'test-verbose' => 'enables verbose testing (TEST_VERBOSE env variable on Makefile.PL, --verbose on Build.PL', { default => 0 } ],
 }
 


### PR DESCRIPTION
Weird things happen in default isn't set to 1 here and you aren't expecting
to be running tests in parallel.