### PR TITLE
Fix GatherDir for minting with symlinked .dzil

### DIFF
--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -173,7 +173,7 @@ sub gather_files {
   my $repo_root = $self->zilla->root;
   my $root = "" . $self->root;
   $root =~ s{^~([\\/])}{require File::HomeDir; File::HomeDir::->my_home . $1}e;
-  $root = path($root)->relative($repo_root)->stringify if path($root)->is_relative;
+  $root = path($repo_root)->child($root)->stringify if path($root)->is_relative;
 
   my $prune_regex = qr/\000/;
   $prune_regex = qr/$prune_regex|$_/


### PR DESCRIPTION
Commit 387e3621edd3b1a1ff9aeef3e821866d68fc2eb1 breaks the search path when
the zilla root is a symlink.

Since the idea of that commit seemed to be to make the gather root relative
to zilla root when the gather root is relative, this commit does that more
directly using the 'child' method on the zilla root.

