### PR TITLE
Allow renaming of files with GatherDir::Template

### DIFF
--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -214,6 +214,8 @@ sub gather_files {
     # _file_from_filename is overloaded in GatherDir::Template
     my $fileobj = $self->_file_from_filename($filename);
 
+    # GatherDir::Template may rename the file
+    $filename = $fileobj->name;
     my $file = path($filename)->relative($root);
     $file = path($self->prefix, $file) if $self->prefix;
 


### PR DESCRIPTION
This supersedes https://github.com/rjbs/Dist-Zilla/pull/464, wherein @rjbs said it would be better as a feature in this plugin.

So, here it is.

#### TemplateModule less than optimal

This stuff is not broken, per se, but it is less than ideal:

While trying this change out I found that `[TemplateModule / :DefaultModuleMaker]` was actually not needed, because it was so trivial to create a `skel/` structure that contained absolutely everything I need. However, `TemplateModule` would still try to create `lib/Module.pm`, causing it to be added twice.

It would be nice to be able to deactivate it, because I found it much tidier to have a skeleton directory structure with suitably-named files, than to have a single outlier `.pm` file just for `TemplateModule` to find.

This is an example of my profile directory structure, if `TemplateModule` were hypothetically deactivated.

    share/profiles/default/
      skel/
        lib/
          DISTNAME/
            Builder.pm
          DISTNAME.pm
        t/
          01app.t
          02pod.t
          03podcoverage.t
        CATNAME.psgi
        CATNAME.conf
        dist.ini

With profile.ini:

    [GatherDir::Template]
    root=skel
    rename.DISTNAME = $dist->name =~ s/-/\//gr
    rename.CATNAME  = lc $dist->name =~ s/-/_/gr 

In reality, we have this:

    share/profiles/
      default/
        DISTNAME.pm
        skel/
          lib/
            DISTNAME/
              Builder.pm
          t/
            01app.t
            02pod.t
            03podcoverage.t
          CATNAME.psgi
          CATNAME.conf
          dist.ini

With profile.ini:

    [TemplateModule / :DefaultModuleMaker]
    template = DISTNAME.pm
    
    [GatherDir::Template]
    root=skel
    rename.DISTNAME = $dist->name =~ s/-/\//gr
    rename.CATNAME  = lc $dist->name =~ s/-/_/gr 
