### PR TITLE
Make PkgDist preserve blank line after 'package'

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - make PkgDist preserve blank line after 'package' for PkgVersion
 
 5.043     2016-01-04 22:54:56-05:00 America/New_York
         - dzil test now supports --extended to set EXTENDED_TESTING (thanks,

--- a/lib/Dist/Zilla/Plugin/PkgDist.pm
+++ b/lib/Dist/Zilla/Plugin/PkgDist.pm
@@ -91,8 +91,12 @@ sub munge_perl {
       $file->name,
     ]);
 
+    # the extra whitespace element ensures we don't swallow up any blanks
+    # lines after 'package ...' in the source file that PkgVersion warns about
+    # if it's missing.
     Carp::carp('error inserting $DIST in ' . $file->name)
-      unless $stmt->insert_after($children[0]->clone)
+      unless $stmt->add_element( PPI::Token::Whitespace->new("\n") )
+      and    $stmt->insert_after($children[0]->clone)
       and    $stmt->insert_after( PPI::Token::Whitespace->new("\n") );
   }
 


### PR DESCRIPTION
I've been struggling with PkgVersion warning:

    [PkgVersion] no blank line for $VERSION after package Foo::Bar::Baz statement

for some time now.

My fix has been to ensure that PkgVersion comes before PkgDist in dist.ini.

For some reason this caused a recent upload (0.0.8.19) to PAUSE to fail with the following:

    Status: Decreasing version number
    =================================

        module : Catalyst::Plugin::ErrorCatcher
        version: undef
        in file: lib/Catalyst/Plugin/ErrorCatcher.pm
        status : Not indexed because
                Catalyst-Plugin-ErrorCatcher-0.0.8.18/lib/Catalyst/Plugin/ErrorCatcher.pm
                in C/CH/CHISEL/Catalyst-Plugin-ErrorCatcher-0.0.8.18.tar.gz
                has a higher version number (0.000008018)

metacpan appears to happily index this upload. I'm presuming it's a bug in that PAUSE indexer; possibly due to the package looking something like this (wild guess):

    package XXX; { ... }

The new module looks like this:

    package Catalyst::Plugin::ErrorCatcher;
    {
      $Catalyst::Plugin::ErrorCatcher::DIST = 'Catalyst-Plugin-ErrorCatcher';
    }
    $Catalyst::Plugin::ErrorCatcher::VERSION = '0.0.8.19';
    # ABSTRACT: Catch application errors and emit them somewhere
    use Moose;
        with 'Catalyst::ClassData';
    use 5.008004;
    use File::Type;
    use IO::File;
    use Module::Pluggable::Object;

The previous version started like this:

    package Catalyst::Plugin::ErrorCatcher;
    $Catalyst::Plugin::ErrorCatcher::VERSION = '0.0.8.18';
    {
      $Catalyst::Plugin::ErrorCatcher::DIST = 'Catalyst-Plugin-ErrorCatcher';
    }
    # ABSTRACT: Catch application errors and emit them somewhere
    use Moose;
        with 'Catalyst::ClassData';
    use 5.008004;
    use File::Type;
    use IO::File;
    use Module::Pluggable::Object;

I attempted a few solutions to 'preserve' the newline for PkgVersion.
In the end I settled on making PkgDist add a blank line before the injected block.

The only problem I can see with this is if there's no blank line before PkgDist is invoked.
This goes against PkgVersion's mantra:

>    By default, PkgVersion look for a blank line after each "package"
>    statement. If it finds one, it inserts the $VERSION assignment on that
>    line. If it doesn't, it will insert a new line, which means the shipped
>    copy of the module will have different line numbers (off by one) than the
>    source. If "die_on_line_insertion" is true, PkgVersion will raise an
>    exception rather than insert a new line.

However, use of PkgDist breaks this desire anyway.
Another reason for adding it there, and not PkgVersion.

I believe that this fix will allow PkgDist and PkgVersion to be used in any order, without slurping blank lines, causing confusing warnings at test/build time.