### PR TITLE
No longer iterate over a reference to zilla->files when munging files

### DIFF
--- a/lib/Dist/Zilla/Role/FileMunger.pm
+++ b/lib/Dist/Zilla/Role/FileMunger.pm
@@ -29,7 +29,8 @@ sub munge_files {
   $self->log_fatal("no munge_file behavior implemented!")
     unless $self->can('munge_file');
 
-  for my $file (@{ $self->zilla->files }) {
+  my @files = @{ $self->zilla->files };
+  for my $file ( @files ) {
     if ($file->is_bytes) {
       $self->log_debug($file->name . " has 'bytes' encoding, skipping...");
       next;

--- a/t/lib/Dist/Zilla/Plugin/MungerThatPrunesPodFiles.pm
+++ b/t/lib/Dist/Zilla/Plugin/MungerThatPrunesPodFiles.pm
@@ -1,0 +1,17 @@
+package Dist::Zilla::Plugin::MungerThatPrunesPodFiles;
+
+use Moose;
+with(
+  'Dist::Zilla::Role::FileMunger',
+);
+
+sub munge_file {
+   my ( $self, $file ) = @_;
+   return unless $file->name =~ m/\.pod$/;
+   
+   $self->zilla->prune_file($file);
+}
+
+__PACKAGE__->meta->make_immutable;
+no Moose;
+1;

--- a/t/plugins/munger-that-prunes.t
+++ b/t/plugins/munger-that-prunes.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+
+use lib 't/lib';
+
+use Test::DZil;
+use YAML::Tiny;
+
+{
+   my $tzil = Builder->from_config(
+      { dist_root => 'corpus/dist/DZT' },
+      {
+         add_files => {
+            'source/Build.pod'  => "This file is cruft.\n",
+            'source/Build2.pod' => "This other file is cruft.\n",
+            'source/Build3.pod' => "This third file is cruft.\n",
+            'source/dist.ini'   => simple_ini(
+               'GatherDir',
+               'MungerThatPrunesPodFiles',
+            ),
+         },
+      },
+   );
+   
+   $tzil->build;
+   
+   my @files = map {; $_->name } @{ $tzil->files };
+   is_filelist(
+      [ @files ],
+      [ qw(lib/DZT/Sample.pm t/basic.t dist.ini) ],
+      'munge_file that call prunes does not mangle $self->zilla->files',
+   );
+}
+
+done_testing;


### PR DESCRIPTION
PR for Issue #512 

[Issue #1](https://github.com/yanick/Dist-Zilla-Plugin-CoalescePod/issues/1) on Dist::Zilla::Plugin::CoalescePod brought to light an issue where if a FileMunger plugin were to issue a `$self->zilla->prune_file($file)` call this could, depending on the order of the files in `$self->zilla->files` mangle the file list, causing munge_file to not be called with a particular file. This PR corrects this by making a copy of `$self->zilla->files` before iterating.

A test, `t/plugins/munger-that-prunes.t`, has been included that reproduces this issue without the array copy mentioned above.