### PR TITLE
Make FakeRelease compatible with UploadToCPAN

### DIFF
--- a/lib/Dist/Zilla/Plugin/FakeRelease.pm
+++ b/lib/Dist/Zilla/Plugin/FakeRelease.pm
@@ -13,6 +13,8 @@ has user => (
   default  => 'AUTHORID',
 );
 
+sub cpanid { shift->user }
+
 sub release {
   my $self = shift;
 

--- a/lib/Dist/Zilla/Plugin/NextRelease.pm
+++ b/lib/Dist/Zilla/Plugin/NextRelease.pm
@@ -246,7 +246,7 @@ The name of the user making this release (from C<user_stash>).
 The email address of the user making this release (from C<user_stash>).
 
 = C<%P>
-The CPAN (PAUSE) id of the user namking this release (from -Releaser plugins;
+The CPAN (PAUSE) id of the user making this release (from -Releaser plugins;
 see L<[UploadToCPAN]|Dist::Zilla::Plugin::UploadToCPAN/username>).
 
 = C<%n>

--- a/t/plugins/nextrelease.t
+++ b/t/plugins/nextrelease.t
@@ -352,18 +352,11 @@ END_CHANGES
                 'GatherDir',
                 [ NextRelease => { format => '%v %P' } ],
                 [ '%PAUSE' => { username  => 'NOBODY', password => 'ohhai' } ],
-                [ UploadToCPAN => ],
+                [ FakeRelease => { user => 'NOBODY' } ],
         ),
       },
     },
   );
-
-  {
-    use Dist::Zilla::Plugin::UploadToCPAN;
-    package Dist::Zilla::Plugin::UploadToCPAN;
-    no warnings 'redefine';
-    sub release { die 'should not be releasing from tests!' }
-  }
 
   is(
     exception { $tzil->build },


### PR DESCRIPTION
Hi!

This change makes [FakeRelease] similar enough to [UploadToCPAN] to be usable in testing of [NextRelease] type plugins.