### PR TITLE
Remove duplicates from the :ExecFiles result

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - remove duplicates from the results of the :ExecFiles filefinder
 
 5.044     2016-04-06 20:32:14-04:00 America/New_York
         - require a newer List::Util to avoid a dumb bug caused by relying on

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -11,6 +11,7 @@ use File::pushd ();
 use Path::Class;
 use Path::Tiny; # because more Path::* is better, eh?
 use Try::Tiny;
+use List::Util 1.45 'uniq';
 
 use namespace::autoclean;
 
@@ -119,7 +120,7 @@ sub _setup_default_plugins {
       style       => 'list',
       code        => sub {
         my $plugins = $_[0]->zilla->plugins_with(-ExecFiles);
-        my @files = map {; @{ $_->find_files } } @$plugins;
+        my @files = uniq map {; @{ $_->find_files } } @$plugins;
 
         return \@files;
       },


### PR DESCRIPTION
This can happen if there are multiple ExecFiles plugins providing overlapping
results.