### PR TITLE
Use a String::RewritePrefix rewriter

### DIFF
--- a/lib/Dist/Zilla/Prereqs.pm
+++ b/lib/Dist/Zilla/Prereqs.pm
@@ -5,8 +5,6 @@ use Moose;
 use MooseX::Types::Moose qw(Bool HashRef);
 
 use CPAN::Meta::Prereqs 2.120630; # add_string_requirement
-use Path::Class ();
-use String::RewritePrefix;
 use CPAN::Meta::Requirements 2.121; # requirements_for_module
 
 use namespace::autoclean;

--- a/lib/Dist/Zilla/Util.pm
+++ b/lib/Dist/Zilla/Util.pm
@@ -5,7 +5,6 @@ package Dist::Zilla::Util;
 
 use Carp ();
 use Encode ();
-use String::RewritePrefix 0.002; # better string context behavior
 
 {
   package
@@ -89,20 +88,17 @@ Prefixes are rewritten as follows:
 
 =cut
 
+use String::RewritePrefix 0.006 rewrite => {
+  -as => '_expand_config_package_name',
+  prefixes => {
+    '=' => '',
+    '@' => 'Dist::Zilla::PluginBundle::',
+    '%' => 'Dist::Zilla::Stash::',
+    ''  => 'Dist::Zilla::Plugin::',
+  },
+};
 sub expand_config_package_name {
-  my ($self, $package) = @_;
-
-  my $str = String::RewritePrefix->rewrite(
-    {
-      '=' => '',
-      '@' => 'Dist::Zilla::PluginBundle::',
-      '%' => 'Dist::Zilla::Stash::',
-      ''  => 'Dist::Zilla::Plugin::',
-    },
-    $package,
-  );
-
-  return $str;
+  shift; goto &_expand_config_package_name
 }
 
 sub _global_config_root {


### PR DESCRIPTION
I noticed that `Dist::Zilla::Util::expand_config_package_name` is called 56 times during a `dzil nop` on the dzil repo. And that it doesn't use a [String::RewritePrefix](https://metacpan.org/pod/String::RewritePrefix) rewriter.
So here is the rewrite of this sub using a rewriter built once.

See also my improvements on String::RewritePrefix itself: rjbs/String-RewritePrefix#2