### PR TITLE
support different prereq relationships in [AutoPrereqs]

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - add 'relationship' option to AutoPrereqs plugin (Karen Etheridge)
 
 5.044     2016-04-06 20:32:14-04:00 America/New_York
         - require a newer List::Util to avoid a dumb bug caused by relying on


### PR DESCRIPTION
It was pretty easy to add, and some dist.inis can be simplified as a result (e.g. MooseX-Runnable, which makes heavy use of "suggests" prereqs via its optional plugin moduels).