### PR TITLE
fix class_type import

### DIFF
--- a/lib/Dist/Zilla/Role/Plugin.pm
+++ b/lib/Dist/Zilla/Role/Plugin.pm
@@ -5,7 +5,7 @@ use Moose::Role;
 with 'Dist::Zilla::Role::ConfigDumper';
 
 use Params::Util qw(_HASHLIKE);
-use MooseX::Types;
+use Moose::Util::TypeConstraints 'class_type';
 
 use namespace::autoclean;
 


### PR DESCRIPTION
using MooseX::Types directly puts MooseX::Types::Base into @ISA!

(as spotted by @kentnl on #distzilla, 2016-03-31 18:20 PDT)