### PR TITLE
reject version ranges rather than warning, if eumm_version is not high enough

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - [MakeMaker] now rejects version ranges in prereqs if eumm_version is
+          not specified to be high enough (7.1101) to guarantee it can be
+          handled (Karen Etheridge)
 
 5.044     2016-04-06 20:32:14-04:00 America/New_York
         - require a newer List::Util to avoid a dumb bug caused by relying on

--- a/lib/Dist/Zilla/Plugin/MakeMaker.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker.pm
@@ -224,9 +224,10 @@ sub write_makefile_args {
   # higher configure-requires version, we should at least warn the user
   # https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/215
   foreach my $phase (qw(configure build test runtime)) {
-    if (my @version_ranges = pairgrep { !version::is_lax($b) } %{ $require_prereqs{$phase} }) {
-      $self->log([
-        'found version range in %s prerequisites, which ExtUtils::MakeMaker cannot parse: %s %s',
+    if (my @version_ranges = pairgrep { defined($b) && !version::is_lax($b) } %{ $require_prereqs{$phase} }
+        and ($self->eumm_version || 0) < '7.1101') {
+      $self->log_fatal([
+        'found version range in %s prerequisites, which ExtUtils::MakeMaker cannot parse (must specify eumm_version of at least 7.1101): %s %s',
         $phase, $_->[0], $_->[1]
       ]) foreach pairs @version_ranges;
     }


### PR DESCRIPTION
This mirrors changes recently released in `[MakeMaker::Awesome]` version 0.37.