### PR TITLE
parentheses must be used for subs that were not loaded at compile time

### DIFF
--- a/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/AutoPrereqs.pm
@@ -208,7 +208,7 @@ sub register_prereqs {
     }
 
     # remove prereqs shipped with current dist
-    $self->log_debug([ 'excluding local packages: %s', sub { join(', ', List::Util::uniq @modules) } ]);
+    $self->log_debug([ 'excluding local packages: %s', sub { join(', ', List::Util::uniq(@modules)) } ]);
     $req->clear_requirement($_) for @modules;
 
     $req->clear_requirement($_) for qw(Config DB Errno NEXT Pod::Functions); # never indexed

--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -108,8 +108,7 @@ sub extract_author_deps {
           : (! Class::Load::try_load_class($_, ($vermap->{$_} ? {-version => $vermap->{$_}} : ())))
         : 1
       }
-    List::Util::uniq
-    @packages;
+    List::Util::uniq(@packages);
 
   return \@final;
 }


### PR DESCRIPTION
This may break eventually without this change, just as using LMU just broke when Moose stopped using it.