### PR TITLE
Make 'run' respect the --trial option

### DIFF
--- a/lib/Dist/Zilla/App/Command/run.pm
+++ b/lib/Dist/Zilla/App/Command/run.pm
@@ -42,6 +42,7 @@ sub abstract { 'run stuff in a dir where your dist is built' }
 sub opt_spec {
   [ 'build!' => 'do the Build actions before running the command; done by default',
                 { default => 1 } ],
+  [ 'trial'  => 'build a trial release that PAUSE will not index' ],
 }
 
 sub description {
@@ -65,7 +66,7 @@ sub execute {
     $self->log("no command supplied to run so using \$$envname: $args->[0]");
   }
 
-  $self->zilla->run_in_build($args, { build => $opt->build });
+  $self->zilla->run_in_build($args, { build => $opt->build, trial => $opt->trial });
 }
 
 1;


### PR DESCRIPTION
The 'run' command needs to respect the same options as 'build', so it can
replicate the same build environment (e.g. plugin configs and build outputs).