### PR TITLE
Improve DZP::FileFinder::ByName::_join_re

### DIFF
--- a/lib/Dist/Zilla/Plugin/FileFinder/ByName.pm
+++ b/lib/Dist/Zilla/Plugin/FileFinder/ByName.pm
@@ -95,16 +95,12 @@ sub mvp_multivalue_args { qw(dirs files matches skips) }
 
 sub _join_re {
   my $list = shift;
-
-  return undef if @$list == 0;
-
-  my $re = qr/(?:$list->[0])/;
-
-  for my $i (1 .. $#$list) {
-    $re = qr/$re|(?:$list->[$i])/;
-  }
-
-  $re;
+  return undef unless @$list;
+  # Special case to avoid stringify+compile
+  return $list->[0] if @$list == 1;
+  # Wrap each element to ensure that alternations are isolated
+  my $re = join('|', map { "(?:$_)" } @$list);
+  qr/$re/
 }
 
 sub find_files {


### PR DESCRIPTION
Faster `_join_re()`:
- do not recompile regexps already compiled by callers (either by type coercion or by explicit `qr//`)
- special case a single element list to avoid regexp stringify+compile
- just `join('|')` to combine multiple regexps
- compile the final result with `qr//`