### PR TITLE
force profile_dir to Path::Class so the caller does not have to

### DIFF
--- a/lib/Dist/Zilla/Role/MintingProfile.pm
+++ b/lib/Dist/Zilla/Role/MintingProfile.pm
@@ -29,4 +29,9 @@ based on your profile with the:
 
 requires 'profile_dir';
 
+around profile_dir => sub {
+  my ($orig, $self, @args) = @_;
+  dir($self->$orig(@args));
+};
+
 1;


### PR DESCRIPTION
This allows for minting profiles to no longer depend on Path::Class.