### PR TITLE
fix test crashing under MSWin32

### DIFF
--- a/t/plugins/gatherdir.t
+++ b/t/plugins/gatherdir.t
@@ -97,7 +97,7 @@ diag 'got log messages: ', explain $tzil->log_messages
   if not Test::Builder->new->is_passing;
 
 
-SKIP: {
+TODO: {
   todo_skip('MSWin32 - skipping symlink test', 1) if $^O eq 'MSWin32';
 
   # tmp/tmp -> tmp/private/tmp
@@ -106,7 +106,8 @@ SKIP: {
   my $link_tmp = path('tmp', 'tmp');
   symlink 'private/tmp', 'tmp/tmp';
 
-  END { $real_tmp->remove_tree; $link_tmp->remove }
+  eval 'END { $real_tmp->remove_tree; $link_tmp->remove }';
+  die $@ if $@;
 
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist' },


### PR DESCRIPTION
`plugins\gatherdir.t` crashes under windows:
```
ok 3 - all files in manifest were on disk
not ok 4 # TODO & SKIP MSWin32 - skipping symlink test
Label not found for "last TODO" at C:/Strawberry/perl/lib/Test/More.pm line 1391.
Can't call method "remove_tree" on an undefined value at t\plugins\gatherdir.t line 109.
END failed--call queue aborted at t\plugins\gatherdir.t line 1391.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 255 just after 4.
```
This PR fixes it, I've verified it doesn't break the test under linux. It may be wiser to use `Scope::Guard` instead of evaling the `END` block, but it seems to work just fine.