### PR TITLE
strip Path::Class from prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -52,6 +52,7 @@ DateTime::TimeZone::Local::Win32 = 1.80
 remove = Config ; why isn't this indexed?? -- rjbs, 2011-02-11
 remove = Dist::Zilla::Tester::_Role ; mistakenly added by autoprereq
 remove = Some::Package::That::Does::Not::Exist::Due::To::A::Typo
+remove = Path::Class    ; only used in fallback code
 
 [CPANFile]
 


### PR DESCRIPTION
Avoid specifying Path::Class as a prereq, since it is only used in fallback code in Dist::Zilla::Path where some other plugin would already have a Path::Class dependency.

(should get at least a week in -trial to shake out any new downstream issues.)