### PR TITLE
#546 ExtraTests: print TAP directly for faster skip

### DIFF
--- a/lib/Dist/Zilla/Plugin/ExtraTests.pm
+++ b/lib/Dist/Zilla/Plugin/ExtraTests.pm
@@ -57,9 +57,9 @@ sub _rewrite {
   my $after = $lines[0] =~ /\A#!/ ? 1 : 0;
   splice @lines, $after, 0, qq|
 BEGIN {
-  unless (\$ENV{$env}) {
-    require Test::More;
-    Test::More::plan(skip_all => 'these tests are for $msg');
+  unless (\$ENV{'$env'}) {
+    print "1..0 # SKIP these tests are for $msg\\n";
+    exit
   }
 }
 |;

--- a/t/plugins/extratests.t
+++ b/t/plugins/extratests.t
@@ -56,7 +56,7 @@ for my $type (@xt_types) {
 
   like(
     $test_program,
-    qr/\$ENV\{$env\}/,
+    qr/\$ENV\{'$env'\}/,
     "we mention $env in the rewritten $type test",
   );
 }


### PR DESCRIPTION
Fix for #546: faster skip_all by printing TAP ourself instead of loading Test::More for that.