### PR TITLE
do not chdir into the source dir when building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ perl:
   - "5.16"
   - "5.14"
 before_install:
-  - git clone git://github.com/rjbs/travis-perl-helpers -b release-testing ~/travis-perl-helpers
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init
   - build-perl
   - perl -V

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - Dist::Zilla::Tester no longer changes into the source directory when
+          building. This may break some plugins that do not prepend
+          $zilla->root to paths when they should.
 
 6.012     2018-04-21 10:20:21+02:00 Europe/Oslo
         - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -487,7 +487,7 @@ sub build_archive {
 
   my $archive = $self->$method($built_in, $basename, $basedir);
 
-  my $file = path($self->archive_filename);
+  my $file = path($self->root, $self->archive_filename);
 
   $self->log("writing archive to $file");
   $archive->write("$file", 9);

--- a/lib/Dist/Zilla/Plugin/ConfirmRelease.pm
+++ b/lib/Dist/Zilla/Plugin/ConfirmRelease.pm
@@ -13,7 +13,7 @@ sub before_release {
                   map {; $_->plugin_name }
                   @{ $self->zilla->plugins_with(-Releaser) };
 
-  $self->log("*** Preparing to release $tgz with $releasers ***");
+  $self->log([ '*** Preparing to release %s with %s ***', $tgz->basename, $releasers ]);
   my $prompt = "Do you want to continue the release process?";
 
   my $default = exists $ENV{DZIL_CONFIRMRELEASE_DEFAULT}

--- a/lib/Dist/Zilla/Plugin/NextRelease.pm
+++ b/lib/Dist/Zilla/Plugin/NextRelease.pm
@@ -152,7 +152,7 @@ sub after_release {
   $self->log_debug([ 'updating contents of %s on disk', $update_fn ]);
 
   # and finally rewrite the changelog on disk
-  path($update_fn)->spew({binmode => $iolayer}, $content);
+  path($self->zilla->root, $update_fn)->spew({binmode => $iolayer}, $content);
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -205,10 +205,6 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
   around build_in => sub {
     my ($orig, $self, $target) = @_;
 
-    # XXX: We *must eliminate* the need for this!  It's only here because right
-    # now building a dist with (root <> cwd) doesn't work. -- rjbs, 2010-03-08
-    my $wd = File::pushd::pushd($self->root);
-
     $target ||= do {
       my $target = path($self->tempdir)->child('build');
       $target->mkpath;
@@ -220,10 +216,6 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
 
   around ['test', 'release'] => sub {
     my ($orig, $self) = @_;
-
-    # XXX: We *must eliminate* the need for this!  It's only here because right
-    # now building a dist with (root <> cwd) doesn't work. -- rjbs, 2010-03-08
-    my $wd = File::pushd::pushd($self->root);
 
     return $self->$orig;
   };

--- a/t/plugins/nextrelease.t
+++ b/t/plugins/nextrelease.t
@@ -25,7 +25,7 @@ END_CHANGES
   with 'Dist::Zilla::Role::AfterRelease';
 
   sub after_release {
-    Path::Tiny::path('Changes')->spew('OHHAI');
+    Path::Tiny::path(shift->zilla->root, 'Changes')->spew('OHHAI');
   }
 }
 


### PR DESCRIPTION
I read "we must!" and "but it doesn't work!" and I thought "OH REALLY, what doesn't work?" and it turns out that there are only two things in core that don't prepend root properly. There may be plugins out there that are naughty. Let's find out!
