### PR TITLE
more x_breaks data

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -70,9 +70,10 @@ Dist::Zilla::Plugin::CopyFilesFromBuild = < 0.161230
 Dist::Zilla::Plugin::ReadmeAnyFromPod = < 0.161170
 Dist::Zilla::Plugin::PodWeaver = <= 4.006
 Dist::Zilla::Plugin::Test::CheckDeps = <= 0.013
-; Dist::Zilla::Plugin::Git = <= 2.036
+Dist::Zilla::Plugin::Git = <= 2.036
 Dist::Zilla::Plugin::Keywords = <= 0.006
 Dist::Zilla::Plugin::RepoFileInjector = <= 0.005
+Dist::Zilla::App::Command::xtest = < 0.029
 
 [Test::CheckBreaks]
 conflicts_module = Moose::Conflicts


### PR DESCRIPTION
If @xdg releases `[CheckChangesHasContent]` before you get to this, then this line should also be added:

    Dist::Zilla::Plugin::CheckChangesHasContent = < 0.007
