### PR TITLE
add x_serialization_backend to metadata

### DIFF
--- a/lib/Dist/Zilla/Plugin/MetaJSON.pm
+++ b/lib/Dist/Zilla/Plugin/MetaJSON.pm
@@ -72,9 +72,6 @@ sub gather_files {
       my $converter = CPAN::Meta::Converter->new($distmeta);
       my $output    = $converter->convert(version => $self->version);
 
-      # note utf8 => 1 is *not* used - so unicode characters remain as-is in
-      # the resulting json string, and therefore an encoding must be used when
-      # the file is written to disk.
       JSON::MaybeXS->new(canonical => 1, pretty => 1, ascii => 1)->encode($output)
       . "\n";
     },

--- a/lib/Dist/Zilla/Plugin/MetaJSON.pm
+++ b/lib/Dist/Zilla/Plugin/MetaJSON.pm
@@ -72,6 +72,10 @@ sub gather_files {
       my $converter = CPAN::Meta::Converter->new($distmeta);
       my $output    = $converter->convert(version => $self->version);
 
+      my $backend = JSON::MaybeXS::JSON();
+      $output->{x_serialization_backend} = sprintf '%s version %s',
+            $backend, $backend->VERSION;
+
       JSON::MaybeXS->new(canonical => 1, pretty => 1, ascii => 1)->encode($output)
       . "\n";
     },

--- a/lib/Dist/Zilla/Plugin/MetaYAML.pm
+++ b/lib/Dist/Zilla/Plugin/MetaYAML.pm
@@ -73,6 +73,9 @@ sub gather_files {
 
       my $converter = CPAN::Meta::Converter->new($distmeta);
       my $output    = $converter->convert(version => $self->version);
+      $output->{x_serialization_backend} = sprintf '%s version %s',
+            'YAML::Tiny', YAML::Tiny->VERSION;
+
       my $yaml = try {
         YAML::Tiny->new($output)->write_string; # text!
       }

--- a/t/plugins/distmeta.t
+++ b/t/plugins/distmeta.t
@@ -39,9 +39,11 @@ use YAML::Tiny;
 
   my $json = $tzil->slurp_file('build/META.json');
   $meta{json} = JSON::MaybeXS->new(utf8 => 0)->decode($json);
+  $meta{json}{x_serialization_backend} = 'ignore';
 
   my $yaml = $tzil->slurp_file('build/META.yml');
   $meta{yaml} = YAML::Tiny->new->read_string($yaml)->[0];
+  $meta{yaml}{x_serialization_backend} = 'ignore';
 
   is_deeply($meta{json}, $meta{yaml}, "META.json is_deeply META.yml");
 
@@ -108,9 +110,11 @@ use YAML::Tiny;
 
   my $json = $tzil->slurp_file('build/META.json');
   $meta{json} = JSON::MaybeXS->new(utf8 => 0)->decode($json);
+  $meta{json}{x_serialization_backend} = 'ignore';
 
   my $yaml = $tzil->slurp_file('build/META.yml');
   $meta{yaml} = YAML::Tiny->new->read_string($yaml)->[0];
+  $meta{yaml}{x_serialization_backend} = 'ignore';
 
   is_deeply($meta{json}, $meta{yaml}, "META.json is_deeply META.yml");
 
@@ -156,9 +160,11 @@ use YAML::Tiny;
 
   my $json = $tzil->slurp_file('build/META.json');
   $meta{json} = JSON::MaybeXS->new(utf8 => 0)->decode($json);
+  $meta{json}{x_serialization_backend} = 'ignore';
 
   my $yaml = $tzil->slurp_file('build/META.yml');
   $meta{yaml} = YAML::Tiny->new->read_string($yaml)->[0];
+  $meta{yaml}{x_serialization_backend} = 'ignore';
 
   for my $type (qw(json yaml)) {
     is_deeply(

--- a/t/plugins/metaresources.t
+++ b/t/plugins/metaresources.t
@@ -14,6 +14,10 @@ my $converted_by = "CPAN::Meta::Converter version "
 
 my $generated_by_re = qr/\A\Q$generated_by\E(?:, \Q$converted_by\E)?\z/;
 
+my $serialization_yaml = 'YAML::Tiny version ' . YAML::Tiny->VERSION;
+my $json_backend = JSON::MaybeXS::JSON();
+my $serialization_json = $json_backend . ' version ' . $json_backend->VERSION;
+
 {
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },
@@ -57,7 +61,8 @@ my $generated_by_re = qr/\A\Q$generated_by\E(?:, \Q$converted_by\E)?\z/;
         bugtracker => 'http://bugs.example.com',
         repository => 'git://example.com/project.git',
       },
-      version => '0.001'
+      version => '0.001',
+      x_serialization_backend => $serialization_yaml,
     },
     'META.yml matches expected 1.4 spec output'
   );
@@ -82,7 +87,8 @@ my $generated_by_re = qr/\A\Q$generated_by\E(?:, \Q$converted_by\E)?\z/;
         homepage   => 'http://example.com',
         repository => superhashof({ url => 'git://example.com/project.git' }),
       },
-      version => '0.001'
+      version => '0.001',
+      x_serialization_backend => $serialization_json,
     },
     'META.json was 2.0 output, old-style resources were upgraded'
   );
@@ -134,7 +140,8 @@ my $generated_by_re = qr/\A\Q$generated_by\E(?:, \Q$converted_by\E)?\z/;
         bugtracker => 'http://bugs.example.com',
         repository => 'git://example.com/project.git',
       },
-      version => '0.001'
+      version => '0.001',
+      x_serialization_backend => $serialization_yaml,
     },
     'META.yml matches expected 1.4 spec output, new style resources were down-graded'
   );
@@ -166,7 +173,8 @@ my $generated_by_re = qr/\A\Q$generated_by\E(?:, \Q$converted_by\E)?\z/;
           web  => 'http://example.com/git/project',
         }
       },
-      version => '0.001'
+      version => '0.001',
+      x_serialization_backend => $serialization_json,
     },
     'META.json was 2.0 output'
   );


### PR DESCRIPTION
 add x_serialization_backend to metadata, as done in CPAN::Meta
    
This was added by rjbs in https://github.com/Perl-Toolchain-Gang/CPAN-Meta/pull/96
