### PR TITLE
Don't depend directly on DateTime::TimeZone::Local::Win32

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -45,9 +45,6 @@ Mixin::Linewise::Readers = 0.100    ; default encodings to UTF-8
 
 DateTime = 0.44 ; CLDR fixes, used by AutoVersion and NextRelease
 
-[OSPrereqs / MSWin32]
-DateTime::TimeZone::Local::Win32 = 1.80
-
 [RemovePrereqs]
 remove = Config ; why isn't this indexed?? -- rjbs, 2011-02-11
 remove = Dist::Zilla::Tester::_Role ; mistakenly added by autoprereq


### PR DESCRIPTION
As of 1.92, DateTime::TimeZone will take care of this. Depending
on it directly risks DT::TZ and DT::TZ::Local::Win32 being out
of sync.

See https://rt.cpan.org/Ticket/Display.html?id=116909 and https://ci.appveyor.com/project/schwern/dist-zilla/build/1.0.4