### PR TITLE
Depend on DateTime::TimeZone directly on Win32.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,7 +46,7 @@ Mixin::Linewise::Readers = 0.100    ; default encodings to UTF-8
 DateTime = 0.44 ; CLDR fixes, used by AutoVersion and NextRelease
 
 [OSPrereqs / MSWin32]
-DateTime::TimeZone::Local::Win32 = 1.80
+DateTime::TimeZone = 1.92
 
 [RemovePrereqs]
 remove = Config ; why isn't this indexed?? -- rjbs, 2011-02-11


### PR DESCRIPTION
DT::TZ::Local::Win32 is a Win32 specific component of DT::TZ and
should not be dependend on directly else it might be out of sync
with an installed version of DT::TZ.

DT::TZ 1.92 is when it started depending on DT::TZ::Local::Win32.

See #563 for more discussion.
