### PR TITLE
Add listdeps options for requires/recommends/suggests.

### DIFF
--- a/corpus/dist/AutoPrereqs/dist.ini
+++ b/corpus/dist/AutoPrereqs/dist.ini
@@ -18,3 +18,10 @@ filename = t/data.bin
 
 [Prereqs / DevelopRequires]
 String::Formatter = 0
+
+[Prereqs / RuntimeRecommends]
+Term::ReadLine::Gnu = 0
+Archive::Tar::Wrapper = 0.15
+
+[Prereqs / RuntimeSuggests]
+PPI::XS = 1.23

--- a/lib/Dist/Zilla/App/Command/listdeps.pm
+++ b/lib/Dist/Zilla/App/Command/listdeps.pm
@@ -26,6 +26,24 @@ Include author dependencies (those listed under C<develop_requires>).
 
 List only dependencies which are unsatisfied.
 
+=head2 --requires / --no-requires
+
+Add required dependencies to the list (or don't).
+
+Default: on.
+
+=head2 --recommends / --no-recommends
+
+Add recommended dependencies to the list (or don't).
+
+Default: on.
+
+=head2 --suggests / --no-suggests
+
+Add suggested dependencies to the list (or don't).
+
+Default: off.
+
 =head2 --versions
 
 Also display the required versions of listed modules.
@@ -53,6 +71,9 @@ sub abstract { "print your distribution's prerequisites" }
 sub opt_spec {
   [ 'develop|author', 'include author/develop dependencies' ],
   [ 'missing', 'list only the missing dependencies' ],
+  [ 'requires!', 'list the required dependencies', { default => 1 } ],
+  [ 'recommends!', 'list the recommended dependencies', { default => 1 } ],
+  [ 'suggests!', 'list the suggested dependencies', {default => 0 } ],
   [ 'versions', 'include required version numbers in listing' ],
   [ 'cpanm-versions', 'format versions for consumption by cpanm' ],
   [ 'json', 'list dependencies by phase, in JSON format' ],
@@ -93,21 +114,22 @@ sub filter_core {
 }
 
 sub extract_dependencies {
-  my ($self, $zilla, $phases, $missing, $omit_core) = @_;
+  my ($self, $zilla, $phases, $opt) = @_;
 
   my $prereqs = $self->prereqs($zilla);
-  $prereqs = filter_core($prereqs, $omit_core) if $omit_core;
+  $prereqs = filter_core($prereqs, $opt->omit_core) if $opt->omit_core;
 
   require CPAN::Meta::Requirements;
   my $req = CPAN::Meta::Requirements->new;
 
   for my $phase (@$phases) {
-    $req->add_requirements( $prereqs->requirements_for($phase, 'requires') );
-    $req->add_requirements( $prereqs->requirements_for($phase, 'recommends') );
+    $req->add_requirements( $prereqs->requirements_for($phase, 'requires') )   if $opt->requires;
+    $req->add_requirements( $prereqs->requirements_for($phase, 'recommends') ) if $opt->recommends;
+    $req->add_requirements( $prereqs->requirements_for($phase, 'suggests') )   if $opt->suggests;
   }
 
   my @required = grep { $_ ne 'perl' } $req->required_modules;
-  if ($missing) {
+  if ($opt->missing) {
     require Module::Runtime;
     @required =
       grep {
@@ -146,7 +168,7 @@ sub execute {
     return 1;
   }
 
-  my %modules = $self->extract_dependencies($self->zilla, \@phases, $opt->missing, $opt->omit_core);
+  my %modules = $self->extract_dependencies($self->zilla, \@phases, $opt);
 
   if ($opt->versions or $opt->cpanm_versions) {
     my @names = sort { lc $a cmp lc $b } keys %modules;

--- a/t/commands/listdeps.t
+++ b/t/commands/listdeps.t
@@ -7,45 +7,88 @@ use Dist::Zilla::App::Tester;
 
 # see also t/plugins/autoprereqs.t
 my %prereqs = (
-  # DZPA::Main should not be extracted
-  'DZPA::Base::Moose1'    => 0,
-  'DZPA::Base::Moose2'    => 0,
-  'DZPA::Base::base1'     => 0,
-  'DZPA::Base::base2'     => 0,
-  'DZPA::Base::base3'     => 0,
-  'DZPA::Base::parent1'   => 0,
-  'DZPA::Base::parent2'   => 0,
-  'DZPA::Base::parent3'   => 0,
-  'DZPA::IgnoreAPI'       => 0,
-  'DZPA::IndentedRequire' => '3.45',
-  'DZPA::IndentedUse'     => '0.13',
-  'DZPA::MinVerComment'   => '0.50',
-  'DZPA::ModRequire'      => 0,
-  'DZPA::NotInDist'       => 0,
-  'DZPA::Role'            => 0,
-  'DZPA::ScriptUse'       => 0,
-  'base'                  => 0,
-  'lib'                   => 0,
-  'parent'                => 0,
-  'perl'                  => 5.008,
-  'strict'                => 0,
-  'warnings'              => 0,
+    requires => {
+        # DZPA::Main should not be extracted
+        'DZPA::Base::Moose1'    => 0,
+        'DZPA::Base::Moose2'    => 0,
+        'DZPA::Base::base1'     => 0,
+        'DZPA::Base::base2'     => 0,
+        'DZPA::Base::base3'     => 0,
+        'DZPA::Base::parent1'   => 0,
+        'DZPA::Base::parent2'   => 0,
+        'DZPA::Base::parent3'   => 0,
+        'DZPA::IgnoreAPI'       => 0,
+        'DZPA::IndentedRequire' => '3.45',
+        'DZPA::IndentedUse'     => '0.13',
+        'DZPA::MinVerComment'   => '0.50',
+        'DZPA::ModRequire'      => 0,
+        'DZPA::NotInDist'       => 0,
+        'DZPA::Role'            => 0,
+        'DZPA::ScriptUse'       => 0,
+        'base'                  => 0,
+        'lib'                   => 0,
+        'parent'                => 0,
+        'perl'                  => 5.008,
+        'strict'                => 0,
+        'warnings'              => 0,
+    },
+    recommends => {
+        'Term::ReadLine::Gnu'   => 0,
+        'Archive::Tar::Wrapper' => 0.15
+    },
+    suggests   => {
+        'PPI::XS'               => 1.23
+    }
 );
 
-{
+my %versions;
+for my $type (keys %prereqs) {
+    @versions{ keys %{$prereqs{$type}} } = values %{$prereqs{$type}};
+}
+
+my @default_prereqs = (keys %{$prereqs{requires}}, keys %{$prereqs{recommends}});
+
+note "no args"; {
     my $output = test_dzil('corpus/dist/AutoPrereqs', [ qw(listdeps) ])->output;
     cmp_deeply(
         [ split("\n", $output) ],
-        bag(grep { $_ ne 'perl' } keys %prereqs),
+        bag(grep { $_ ne 'perl' } @default_prereqs),
         'all prereqs listed as output',
     );
 }
 
-{
+note "--no-requires"; {
+    my $output = test_dzil('corpus/dist/AutoPrereqs', [ qw(listdeps --no-requires) ])->output;
+    cmp_deeply(
+        [ split("\n", $output) ],
+        bag(grep { $_ ne 'perl' } keys %{$prereqs{recommends}}),
+        'no recommended prereqs listed as output',
+    );
+}
+
+note "--no-recommends"; {
+    my $output = test_dzil('corpus/dist/AutoPrereqs', [ qw(listdeps --no-recommends) ])->output;
+    cmp_deeply(
+        [ split("\n", $output) ],
+        bag(grep { $_ ne 'perl' } keys %{$prereqs{requires}}),
+        'no recommended prereqs listed as output',
+    );
+}
+
+note "--suggests"; {
+    my $output = test_dzil('corpus/dist/AutoPrereqs', [ qw(listdeps --suggests) ])->output;
+    cmp_deeply(
+        [ split("\n", $output) ],
+        bag(grep { $_ ne 'perl' } @default_prereqs, keys %{$prereqs{suggests}}),
+        'no recommended prereqs listed as output',
+    );
+}
+
+note "--versions"; {
     my $output = test_dzil('corpus/dist/AutoPrereqs', [ qw(listdeps --versions) ])->output;
     cmp_deeply(
         [ split("\n", $output) ],
-        bag(map { $_ . ' = ' . $prereqs{$_} } grep { $_ ne 'perl' } keys %prereqs),
+        bag(map { $_ . ' = ' . $versions{$_} } grep { $_ ne 'perl' } @default_prereqs),
         'prereqs listed with versions for --versions',
     );
 }
@@ -55,7 +98,7 @@ foreach my $arg (qw(--author --develop))
     my $output = test_dzil('corpus/dist/AutoPrereqs', [ 'listdeps', $arg])->output;
     cmp_deeply(
         [ split("\n", $output) ],
-        bag('String::Formatter', grep { $_ ne 'perl' } keys %prereqs),
+        bag('String::Formatter', grep { $_ ne 'perl' } @default_prereqs),
         'develop prereqs included in output for ' . $arg,
     );
 }


### PR DESCRIPTION
This allows more control over dependency listing.

`dzil listdeps` includes the recommended deps. The recommended Dist::Zilla deps Term::ReadLine::Gnu and Archive::Tar::Wrapper are unlikely to work on Windows. Allowing `dzil listdeps --no-recommends` will allow #562 to work and make it easier for Windows users to work with dzil from the repo.
