### PR TITLE
fix ExtraTests skip message quoting

### DIFF
--- a/lib/Dist/Zilla/Plugin/ExtraTests.pm
+++ b/lib/Dist/Zilla/Plugin/ExtraTests.pm
@@ -58,7 +58,7 @@ sub _rewrite {
   splice @lines, $after, 0, qq|
 BEGIN {
   unless (\$ENV{$env}) {
-    print "1..0 # SKIP these tests are for $msg\\n";
+    print qq{1..0 # SKIP these tests are for $msg\\n};
     exit
   }
 }


### PR DESCRIPTION
This is needed since the smoke testing message contains internal double-quotes (i.e., '"smoke bot" ...').