### PR TITLE
make test less picky about the expected exception

### DIFF
--- a/t/diagnostics/plugin-fail.t
+++ b/t/diagnostics/plugin-fail.t
@@ -43,8 +43,7 @@ subtest "BrokenPlugin4" => sub {
   my $error = exception { mkconfig( 'corpus/dist/DZT', [ 'BrokenPlugin4' => {} ] ) };
 
   ok( $error, "Failure occurs when a plugin is broken" );
-  like( $error, qr{Can't locate}, "Exception explains that it couldn't load the plugin 2-layers down" );
-  like( $error, qr{Some/Package/That/Does/Not/Exist/}, "Exception reports the original problem" );
+  like( $error, qr{Some(/|::)Package(/|::)That(/|::)Does(/|::)Not(/|::)Exist}, "Exception reports the original problem" );
 };
 
 subtest "Not::A::Plugin" => sub {


### PR DESCRIPTION
Starting with Moose 2.1806, the exception is now:
You can only consume roles, Some::Package::That::Does::Not::Exist::Due::To::A::Typo is not a Moose role at Moose/Exporter.pm line 419

This may be reverted, but there is no great need to test for the specific error thrown when a plugin uses a non-existent role.

(fixes #567)