### PR TITLE
also run Module::Runtime::Conflicts in t/zzz-check-breaks.t

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -76,4 +76,6 @@ Dist::Zilla::Plugin::RepoFileInjector = <= 0.005
 Dist::Zilla::App::Command::xtest = < 0.029
 
 [Test::CheckBreaks]
+:version = 0.017
 conflicts_module = Moose::Conflicts
+conflicts_module = Module::Runtime::Conflicts


### PR DESCRIPTION
This doesn't add any additional prereqs, because Module::Runtime::Conflicts is
a prereq of Moose.