### PR TITLE
versions must now be strict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ perl:
   - "5.16"
   - "5.14"
 before_install:
-  - git clone git://github.com/rjbs/travis-perl-helpers -b release-testing ~/travis-perl-helpers
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init
   - build-perl
   - perl -V

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - version strings must now pass version.pm's is_strict checks, which
+          eliminates such discouraged constructs as v1.23_01.
 
 6.012     2018-04-21 10:20:21+02:00 Europe/Oslo
         - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in

--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -7,10 +7,10 @@ with 'Dist::Zilla::Role::ConfigDumper';
 # This comment has fün̈n̈ÿ characters.
 
 use MooseX::Types::Moose qw(ArrayRef Bool HashRef Object Str);
-use MooseX::Types::Perl qw(DistName LaxVersionStr);
+use MooseX::Types::Perl qw(DistName);
 use Moose::Util::TypeConstraints;
 
-use Dist::Zilla::Types qw(Path License ReleaseStatus);
+use Dist::Zilla::Types qw(Path License ReleaseStatus VersionStr);
 
 use Log::Dispatchouli 1.100712; # proxy_loggers, quiet_fatal
 use Dist::Zilla::Path;
@@ -71,15 +71,14 @@ This is the version of the distribution to be created.
 =cut
 
 has _version_override => (
-  isa => LaxVersionStr,
+  isa => VersionStr,
   is  => 'ro' ,
   init_arg => 'version',
 );
 
-# XXX: *clearly* this needs to be really much smarter -- rjbs, 2008-06-01
 has version => (
   is   => 'rw',
-  isa  => LaxVersionStr,
+  isa  => VersionStr,
   lazy => 1,
   init_arg  => undef,
   builder   => '_build_version',

--- a/lib/Dist/Zilla/Types.pm
+++ b/lib/Dist/Zilla/Types.pm
@@ -17,6 +17,7 @@ use MooseX::Types -declare => [qw(
   License OneZero YesNoStr ReleaseStatus 
   Path ArrayRefOfPaths
   _Filename
+  VersionStr
 )];
 use MooseX::Types::Moose qw(Str Int Defined ArrayRef);
 use Path::Tiny;
@@ -46,5 +47,11 @@ coerce OneZero, from YesNoStr, via { /\Ay/i ? 1 : 0 };
 subtype _Filename, as Str,
   where   { $_ !~ qr/(?:\x{0a}|\x{0b}|\x{0c}|\x{0d}|\x{85}|\x{2028}|\x{2029})/ },
   message { "Filename not a Str, or contains a newline or other vertical whitespace" };
+
+use MooseX::Types::Perl qw(LaxVersionStr);
+subtype VersionStr, as LaxVersionStr,
+  # non-decimal versions cannot use underscores
+  where { /_/ && (/^v/ || (()= /\./g) > 1) ? 0 : 1 },
+  message { 'Only decimal versions can contain underscores' };
 
 1;

--- a/t/types.t
+++ b/t/types.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+
+use Test::More 0.88;
+
+use Dist::Zilla::Types qw(VersionStr);
+
+ok(is_VersionStr($_), "$_ isa VersionStr") foreach qw(1.23 1.23000 1.004_002 v1.23 v1.23.45);
+
+ok(!is_VersionStr($_), "$_ is not a VersionStr") foreach qw(v1.23_01 v1.23.45_01 1.23.45_01);
+
+done_testing;


### PR DESCRIPTION
This will prevent discouraged formats from being used, even though CPAN::Meta
still lets some of them in (despite contradictory language in
CPAN::Meta::Spec).