### PR TITLE
also prune tmp/

### DIFF
--- a/lib/Dist/Zilla/Plugin/PruneCruft.pm
+++ b/lib/Dist/Zilla/Plugin/PruneCruft.pm
@@ -74,6 +74,7 @@ sub exclude_file {
   # Avoid bundling fatlib/ dir created by App::FatPacker
   # https://github.com/andk/pause/pull/65
   return 1 if substr($file->name, 0, 7) eq 'fatlib/';
+  return 1 if substr($file->name, 0, 4) eq 'tmp/';
 
   if (my $file = $file->name =~ s/\.c$//r) {
     for my $other (@{ $self->zilla->files }) {


### PR DESCRIPTION
Dist::Zilla::Tester might leave this (non-empty) directory behind if some
tests failed, but it should never be included in the distribution.