### PR TITLE
treat Module::Runtime as an "internal" module for carping

### DIFF
--- a/lib/Dist/Zilla/App.pm
+++ b/lib/Dist/Zilla/App.pm
@@ -8,6 +8,8 @@ use App::Cmd::Setup 0.330 -app; # better compilation error detection
 use Carp ();
 use Try::Tiny;
 
+$Carp::Internal{'Module::Runtime'} = 1;
+
 sub global_opt_spec {
   my ($self) = @_;
 


### PR DESCRIPTION
This means that if a module (e.g. a Dist::Zilla plugin) being loaded via
Module::Runtime issues a warning, we will look to the caller for warning
categories, rather than Module::Runtime itself (which happens to disable *all*
warnings).