### PR TITLE
continue to find [=inc::SomePlugin] even when . is not in @INC

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - continue to support local plugins like [=inc::SomePlugin] when . is
+          no longer in @INC
 
 6.009     2017-03-04 11:16:37-05:00 America/New_York
         - update DateTime::TimeZone prereq on Win32 to improve workingness

--- a/lib/Dist/Zilla/Tester.pm
+++ b/lib/Dist/Zilla/Tester.pm
@@ -187,7 +187,7 @@ sub minter { 'Dist::Zilla::Tester::_Minter' }
     # We do this so that . in @INC will find plugins like [=inc::YourFace]
     # -- rjbs, 2016-04-24
     my $wd = File::pushd::pushd($arg->{dist_root});
-
+    push @INC, $arg->{dist_root};
 
     local $ENV{DZIL_GLOBAL_CONFIG_ROOT};
     $ENV{DZIL_GLOBAL_CONFIG_ROOT} = $tester_arg->{global_config_root}


### PR DESCRIPTION
I think it's probably safe now to remove the chdir into dist_root during test builds, but this change should be done separately (and in a -TRIAL release) in case some other distributions' tests were depending on it.