### PR TITLE
Keep dist-root in @INC beyond Perl 5.26

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -36,6 +36,7 @@ sub from_config {
   $arg ||= {};
 
   my $root = path($arg->{dist_root} || '.');
+  unshift @INC, $root->absolute->stringify;
 
   my $sequence = $class->_load_config({
     root   => $root,

--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -105,7 +105,7 @@ sub extract_author_deps {
 
   if ($missing) {
     require Module::Runtime;
-
+    unshift @INC, $root->absolute->stringify;
     @packages =
       grep {
         $_ eq 'perl'


### PR DESCRIPTION
The only thing that makes sense is to ensure CWD of some description is
in @INC at some stage before plugins are actually loaded, because
that's the traditional expectation.

Basically, this option is the only option that works. There's no viable
way to scope @INC changes to anything narrower without breaking the
usage entirely.

There's no sane way to limit the depth of @INC changes either, even if
we wanted to.

And if you have vulnerable code in your project source tree that you're
worried about, you're pretty much beyond screwed already, and you're
about to be screwing CPAN when you ship next, and no amount of @INC
magic will save you.

Closes: https://github.com/rjbs/Dist-Zilla/issues/581
Closes: https://github.com/rjbs/Dist-Zilla/pull/590
Bug: https://bugs.gentoo.org/613586