### PR TITLE
do not add Archive::Tar::Wrapper as a required prereq

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in
+          release 6.011).
 
 6.011     2018-02-11 12:57:02-05:00 America/New_York
         - stashes can now be added in [%Stash] form from a bundle (thanks,

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -480,7 +480,7 @@ sub build_archive {
 
   $_->before_archive for @{ $self->plugins_with(-BeforeArchive) };
 
-  my $method = eval { require Archive::Tar::Wrapper;
+  my $method = eval { +require Archive::Tar::Wrapper;
                       Archive::Tar::Wrapper->VERSION('0.15'); 1 }
              ? '_build_archive_with_wrapper'
              : '_build_archive';


### PR DESCRIPTION
This mistakenly occurred as a result of commit ff42620c.