### PR TITLE
Add File::Copy::Recursive version to avoid tests fail

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -42,6 +42,7 @@ Config::MVP::Reader::INI = 2.101461 ; allow spaces in plugin name
 Data::Section            = 0.200000 ; default encodings to UTF-8
 ExtUtils::Manifest       = 1.54     ; for ManifestSkip that needs maniskip()
 Mixin::Linewise::Readers = 0.100    ; default encodings to UTF-8
+File::Copy::Recursive    = 0.40     ; 0.39 version cause failed tests in GatherDir
 
 DateTime = 0.44 ; CLDR fixes, used by AutoVersion and NextRelease
 


### PR DESCRIPTION
Test for GatherDir fail if you have File::Copy::Recursive@0.39
installed