### PR TITLE
Explicitly set $ENV{TZ} in three test files.

### DIFF
--- a/t/plugins/distmeta.t
+++ b/t/plugins/distmeta.t
@@ -9,6 +9,8 @@ use Test::DZil;
 use JSON::MaybeXS;
 use YAML::Tiny;
 
+local $ENV{TZ} = 'America/New_York';
+
 {
   # 2.0
   my $tzil = Builder->from_config(

--- a/t/plugins/license.t
+++ b/t/plugins/license.t
@@ -6,6 +6,8 @@ use utf8;
 use autodie;
 use Test::DZil;
 
+local $ENV{TZ} = 'America/New_York';
+
 subtest "ASCII-only author" => sub {
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },

--- a/t/plugins/readme.t
+++ b/t/plugins/readme.t
@@ -6,6 +6,8 @@ use utf8;
 use autodie;
 use Test::DZil;
 
+local $ENV{TZ} = 'America/New_York';
+
 my $tzil = Builder->from_config(
   { dist_root => 'corpus/dist/DZT' },
   {


### PR DESCRIPTION
As per usage in t/plugins/nextrelease.t.

When testing Build::Zilla in a FreeBSD-11 virtual machine, failures in
three test files were encountered.  In each case, the failure occurred
when '$tzil->build;' was called in a block where the file being
processed contained non-ASCII text.  In each case, an exception was
thrown whose text begins: "Cannot determine local time zone".  This
message is believed to come from DateTime::TimeZone::Local.
(https://grep.metacpan.org/search?qci=&q=Cannot%20determine%20local%20time%20zone&qft=&qd=DateTime-TimeZone&f=lib%2FDateTime%2FTimeZone%2FLocal.pm)

For: https://github.com/rjbs/Dist-Zilla/issues/586