### PR TITLE
Some MakeMaker fixes for underscores in ExtUtils::MakeMaker $VERSION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ perl:
   - "5.16"
   - "5.14"
 before_install:
-  - git clone git://github.com/rjbs/travis-perl-helpers -b release-testing ~/travis-perl-helpers
+  - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init
   - build-perl
   - perl -V

--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for {{$dist->name}}
 {{$NEXT}}
         - quotes are used around eumm_version when necessary to ensure the proper
           version check is done
+        - also check use quotes when testing ExtUtils::MakeMaker for the
+          existence of various features
 
 6.012     2018-04-21 10:20:21+02:00 Europe/Oslo
         - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - quotes are used around eumm_version when necessary to ensure the proper
+          version check is done
 
 6.012     2018-04-21 10:20:21+02:00 Europe/Oslo
         - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in

--- a/lib/Dist/Zilla/Plugin/MakeMaker.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker.pm
@@ -106,7 +106,7 @@ my {{ $WriteMakefileArgs }}
 
 my {{ $fallback_prereqs }}
 
-unless ( eval { ExtUtils::MakeMaker->VERSION(6.63_03) } ) {
+unless ( eval { ExtUtils::MakeMaker->VERSION('6.63_03') } ) {
   delete $WriteMakefileArgs{TEST_REQUIRES};
   delete $WriteMakefileArgs{BUILD_REQUIRES};
   $WriteMakefileArgs{PREREQ_PM} = \%FallbackPrereqs;

--- a/lib/Dist/Zilla/Plugin/MakeMaker.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker.pm
@@ -97,7 +97,10 @@ use warnings;
 
 {{ $perl_prereq ? qq[use $perl_prereq;] : ''; }}
 
-use ExtUtils::MakeMaker{{ defined $eumm_version && 0+$eumm_version ? ' ' . $eumm_version : '' }};
+use ExtUtils::MakeMaker{{
+    0+$eumm_version
+        ? ' ' . (0+$eumm_version eq $eumm_version ? $eumm_version : "'" . $eumm_version . "'")
+        : '' }};
 {{ $share_dir_code{preamble} || '' }}
 my {{ $WriteMakefileArgs }}
 

--- a/t/plugins/makemaker.t
+++ b/t/plugins/makemaker.t
@@ -151,4 +151,37 @@ use Test::DZil;
     if not Test::Builder->new->is_passing;
 }
 
+{
+  my $tzil = Builder->from_config(
+    { dist_root => 'does-not-exist' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          'GatherDir',
+          [ 'MakeMaker' => { eumm_version => '6.55_02' } ],
+        ),
+        'source/lib/Foo.pm' => "package Foo;\n1\n",
+      },
+    },
+  );
+
+  $tzil->chrome->logger->set_debug(1);
+  is(
+    exception { $tzil->build },
+    undef,
+    'build proceeds normally',
+  );
+
+  my $content = $tzil->slurp_file('build/Makefile.PL');
+
+  like(
+    $content,
+    qr/^use ExtUtils::MakeMaker '6.55_02';$/m,
+    'EUMM version uses quotes to prevent losing information from numification',
+  );
+
+  diag 'got log messages: ', explain $tzil->log_messages
+    if not Test::Builder->new->is_passing;
+}
+
 done_testing;


### PR DESCRIPTION
These reflect changes released in Dist::Zilla::Plugin::MakeMaker::Awesome 0.43, 0.44 and 0.45.

- ensure that version checks against eumm_version work when ExtUtils::MakeMaker itself had an underscore in its $VERSION (which occurs in at least one stable perl)
- ensure that static version checks also do the right thing against such EUMM versions