### PR TITLE
also add . to @INC for "dzil authordeps --missing"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - the build directory is also added to @INC when evaluating 'dzil
+          authordeps --missing'.
 
 6.012     2018-04-21 10:20:21+02:00 Europe/Oslo
         - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in

--- a/corpus/dist/AuthorDeps/LocalPlugin.pm
+++ b/corpus/dist/AuthorDeps/LocalPlugin.pm
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+
+use Moose;
+with 'Dist::Zilla::Role::Plugin';
+
+1;

--- a/corpus/dist/AuthorDeps/dist.ini
+++ b/corpus/dist/AuthorDeps/dist.ini
@@ -6,7 +6,7 @@ copyright_holder = foobar
 copyright_year   = 2009
 
 ; authordep perl = 5.005
-; authordep List::MoreUtils = != 0.407
+; authordep List::MoreUtils = 0.407
 ; authordep Foo::Bar = 1.23 ; this is an explanation for this dep
 
 :version = 5.001

--- a/corpus/dist/AuthorDeps/dist.ini
+++ b/corpus/dist/AuthorDeps/dist.ini
@@ -25,3 +25,5 @@ skip = ^DZPA::Skip
 :version = 5.0
 encoding = bytes
 filename = t/data.bin
+
+[=LocalPlugin]

--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -113,6 +113,7 @@ sub extract_author_deps {
         : do {
             my $m = $_;
             ! eval {
+              local @INC = @INC; push @INC, $root;
               # This will die if module is missing
               Module::Runtime::require_module($m);
               my $v = $vermap->{$m};

--- a/t/commands/authordeps.t
+++ b/t/commands/authordeps.t
@@ -27,4 +27,24 @@ cmp_deeply(
     "authordeps in corpus/dist/AuthorDeps"
 ) or diag explain $authordeps;
 
+SKIP: {
+
+  skip 'this test requires the local plugins to have a $VERSION assigned', 1
+    if not eval { require Dist::Zilla::Plugin::Encoding; Dist::Zilla::Plugin::Encoding->VERSION('5.000'); 1 };
+
+  my $missing_authordeps =
+    Dist::Zilla::Util::AuthorDeps::extract_author_deps(
+      'corpus/dist/AuthorDeps',
+      1
+    );
+
+  cmp_deeply(
+    $missing_authordeps,
+    [
+      +{ 'Foo::Bar' => '1.23' },
+    ],
+    "missing authordeps in corpus/dist/AuthorDeps"
+  ) or diag explain $missing_authordeps;
+}
+
 done_testing;

--- a/t/commands/authordeps.t
+++ b/t/commands/authordeps.t
@@ -17,7 +17,7 @@ cmp_deeply(
     $authordeps,
     [
       +{ perl => '5.005' },
-      +{ 'List::MoreUtils'=> '!= 0.407' },
+      +{ 'List::MoreUtils' => '0.407' },
       +{ 'Foo::Bar' => '1.23' },
       +{ 'Dist::Zilla' => '5.001' },
       ( map { +{"Dist::Zilla::Plugin::$_" => '5.0'} } qw<AutoPrereqs Encoding ExecDir> ),

--- a/t/commands/authordeps.t
+++ b/t/commands/authordeps.t
@@ -22,6 +22,7 @@ cmp_deeply(
       +{ 'Dist::Zilla' => '5.001' },
       ( map { +{"Dist::Zilla::Plugin::$_" => '5.0'} } qw<AutoPrereqs Encoding ExecDir> ),
       ( map { +{"Dist::Zilla::Plugin::$_" => 0} } qw<GatherDir MetaYAML> ),
+      +{ 'LocalPlugin' => '0' },
       +{ 'Software::License::Perl_5' => '0' },
     ],
     "authordeps in corpus/dist/AuthorDeps"

--- a/t/commands/authordeps.t
+++ b/t/commands/authordeps.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More 0.88 tests => 1;
+use Test::More 0.88;
 use Test::Deep;
 
 use autodie;


### PR DESCRIPTION
Dist::Zilla 6.012 is compatible with no-.-in-@INC, with the exception of `dzil authordeps --missing`, which still fails to find local plugins.  Here we add it in.

As this fixes an existing bug with modern perls, rather than adding new features, it is suitable for merge in the v6 series.