### PR TITLE
Add test for Plugin::CPANFile

### DIFF
--- a/t/plugins/cpanfile.t
+++ b/t/plugins/cpanfile.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::DZil;
+
+is cpanfile('build/cpanfile') => <<INI, "cpanfile contains requirements";
+requires "strict" => "0";
+requires "warnings" => "0";
+INI
+
+ok cpanfile('build/otherfile' => { filename => 'otherfile' }),
+  "non-default filename";
+
+done_testing;
+
+sub cpanfile {
+  my $filename = shift;
+
+  my $opts = @_ ? [ map { (CPANFile => $_) } @_ ] : 'CPANFile';
+
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZ1' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(qw< GatherDir AutoPrereqs  >, $opts),
+      },
+    },
+  );
+
+  $tzil->build;
+
+  return $tzil->slurp_file($filename);
+}


### PR DESCRIPTION
I had the idea of adding a `comment` parameter to `Plugin::CPANFile` and started by writing a test for the existing module. Here is the test for the current state of the plugin.

Just after finishing the original idea I realized there is https://github.com/rjbs/Dist-Zilla/pull/629 which is nearly equivalent to my changes but has a reasonable default comment. For my implementation see
https://github.com/dboehmer/Dist-Zilla/tree/plugin-cpanfile-comments

You might want to merge this PR before https://github.com/rjbs/Dist-Zilla/pull/629 and add add a change to the test to that PR. I volunteer to deliver that patch to #629.