### PR TITLE
Add SPDX expression to the metadata

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -15,7 +15,7 @@ use Dist::Zilla::Types qw(Path License ReleaseStatus);
 use Log::Dispatchouli 1.100712; # proxy_loggers, quiet_fatal
 use Dist::Zilla::Path;
 use List::Util 1.33 qw(first none);
-use Software::License 0.101370; # meta2_name
+use Software::License 0.103014; # spdx_expression()
 use String::RewritePrefix;
 use Try::Tiny;
 
@@ -595,7 +595,7 @@ sub _build_distmeta {
     $meta = $meta_merge->merge($meta, $_->metadata);
   }
 
-  $meta = $meta_merge->merge($meta, {
+  my %meta_main = (
     'meta-spec' => {
       version => 2,
       url     => 'https://metacpan.org/pod/CPAN::Meta::Spec',
@@ -613,7 +613,12 @@ sub _build_distmeta {
                     . ' version '
                     . ($self->VERSION // '(undef)'),
     x_generated_by_perl => "$^V", # v5.24.0
-  });
+  );
+  if (my $spdx = $self->license->spdx_expression) {
+    $meta_main{x_spdx_expression} = $spdx;
+  }
+
+  $meta = $meta_merge->merge($meta, \%meta_main);
 
   return $meta;
 }

--- a/t/plugins/distmeta-merge.t
+++ b/t/plugins/distmeta-merge.t
@@ -57,6 +57,7 @@ use Test::Deep;
       version => '0.001',
       keywords => [ qw(foo bar dog cat) ],
       x_generated_by_perl => "$^V",
+      x_spdx_expression => 'Artistic-1.0-Perl OR GPL-1.0-or-later',
     },
     'metadata is correctly merged together',
   );

--- a/t/plugins/metaresources.t
+++ b/t/plugins/metaresources.t
@@ -64,6 +64,7 @@ my $serialization_json = $json_backend . ' version ' . $json_backend->VERSION;
       version => '0.001',
       x_generated_by_perl => "$^V",
       x_serialization_backend => $serialization_yaml,
+      x_spdx_expression => 'Artistic-1.0-Perl OR GPL-1.0-or-later',
     },
     'META.yml matches expected 1.4 spec output'
   );
@@ -91,6 +92,7 @@ my $serialization_json = $json_backend . ' version ' . $json_backend->VERSION;
       version => '0.001',
       x_generated_by_perl => "$^V",
       x_serialization_backend => $serialization_json,
+      x_spdx_expression => 'Artistic-1.0-Perl OR GPL-1.0-or-later',
     },
     'META.json was 2.0 output, old-style resources were upgraded'
   );
@@ -145,6 +147,7 @@ my $serialization_json = $json_backend . ' version ' . $json_backend->VERSION;
       version => '0.001',
       x_generated_by_perl => "$^V",
       x_serialization_backend => $serialization_yaml,
+      x_spdx_expression => 'Artistic-1.0-Perl OR GPL-1.0-or-later',
     },
     'META.yml matches expected 1.4 spec output, new style resources were down-graded'
   );
@@ -179,6 +182,7 @@ my $serialization_json = $json_backend . ' version ' . $json_backend->VERSION;
       version => '0.001',
       x_generated_by_perl => "$^V",
       x_serialization_backend => $serialization_json,
+      x_spdx_expression => 'Artistic-1.0-Perl OR GPL-1.0-or-later',
     },
     'META.json was 2.0 output'
   );


### PR DESCRIPTION
This adds an [SPDX](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange) license expression to the metadata. This allows better signaling of licenses to downstream users and vendors.