### PR TITLE
First shot at fix for issue #632

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -802,6 +802,13 @@ non-zero, the directory will be left in place.
 sub run_in_build {
   my ($self, $cmd, $arg) = @_;
 
+
+  # eliminate the no-options parameter, since indicating this as a first
+  # parameter does not work
+  if ($cmd->[0] eq '--') {
+    shift @{$cmd};
+  }
+
   $self->log_fatal("you can't build without any BuildRunner plugins")
     unless ($arg and exists $arg->{build} and ! $arg->{build})
         or @{ $self->plugins_with(-BuildRunner) };


### PR DESCRIPTION
Hard to fix something, which does not seem to have a proper name and convention.

> Two hyphen-minus characters without following letters (--) may indicate that the remaining arguments should not be treated as options, which is useful for example if a file name itself begins with a hyphen,or if further arguments are meant for an inner command (e.g., sudo).

Ref: https://en.wikipedia.org/wiki/Command-line_interface#Option_conventions_in_Unix-like_systems