### PR TITLE
remove all uses of File::HomeDir

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - replace uses of File::HomeDir with a simple glob()
 
 6.012     2018-04-21 10:20:21+02:00 Europe/Oslo
         - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in

--- a/lib/Dist/Zilla/Plugin/GatherDir.pm
+++ b/lib/Dist/Zilla/Plugin/GatherDir.pm
@@ -3,6 +3,7 @@ package Dist::Zilla::Plugin::GatherDir;
 
 use Moose;
 use Dist::Zilla::Types qw(Path);
+use Dist::Zilla::Util;
 with 'Dist::Zilla::Role::FileGatherer';
 
 use namespace::autoclean;
@@ -12,7 +13,7 @@ use namespace::autoclean;
 This is a very, very simple L<FileGatherer|Dist::Zilla::Role::FileGatherer>
 plugin.  It looks in the directory named in the L</root> attribute and adds all
 the files it finds there.  If the root begins with a tilde, the tilde is
-replaced with the current user's home directory according to L<File::HomeDir>.
+passed through C<glob()> first.
 
 Almost every dist will be built with one GatherDir plugin, since it's the
 easiest way to get files from disk into your dist.  Most users just need:
@@ -175,7 +176,7 @@ sub gather_files {
 
   my $repo_root = $self->zilla->root;
   my $root = "" . $self->root;
-  $root =~ s{^~([\\/])}{require File::HomeDir; File::HomeDir::->my_home . $1}e;
+  $root =~ s{^~([\\/])}{ Dist::Zilla::Util->homedir . $1 }e;
   $root = path($root)->absolute($repo_root)->stringify if path($root)->is_relative;
 
   my $prune_regex = qr/\000/;

--- a/lib/Dist/Zilla/Plugin/GatherFile.pm
+++ b/lib/Dist/Zilla/Plugin/GatherFile.pm
@@ -8,6 +8,7 @@ with 'Dist::Zilla::Role::FileGatherer';
 use MooseX::Types::Moose 'ArrayRef';
 use Path::Tiny;
 use Dist::Zilla::File::OnDisk;
+use Dist::Zilla::Util;
 use namespace::autoclean;
 
 =head1 SYNOPSIS
@@ -20,8 +21,7 @@ use namespace::autoclean;
 This is a very, very simple L<FileGatherer|Dist::Zilla::Role::FileGatherer>
 plugin.  It adds all the files referenced by the C<filename> option that are
 found in the directory named in the L</root> attribute.  If the root begins
-with a tilde, the tilde is replaced with the current user's home directory
-according to L<File::HomeDir>.
+with a tilde, the tilde is passed through C<glob()> first.
 
 Since normally every distribution will use a GatherDir plugin, you would only
 need to use the GatherFile plugin if the file was already being excluded (e.g.
@@ -97,7 +97,7 @@ sub gather_files {
 
   my $repo_root = $self->zilla->root;
   my $root = "" . $self->root;
-  $root =~ s{^~([\\/])}{require File::HomeDir; File::HomeDir::->my_home . $1}e;
+  $root =~ s{^~([\\/])}{ Dist::Zilla::Util->homedir . $1 }e;
   $root = path($root);
   $root = $root->absolute($repo_root) if path($root)->is_relative;
 

--- a/lib/Dist/Zilla/Plugin/UploadToCPAN.pm
+++ b/lib/Dist/Zilla/Plugin/UploadToCPAN.pm
@@ -7,6 +7,7 @@ with qw(Dist::Zilla::Role::BeforeRelease Dist::Zilla::Role::Releaser);
 use File::Spec;
 use Moose::Util::TypeConstraints;
 use Scalar::Util qw(weaken);
+use Dist::Zilla::Util;
 use Try::Tiny;
 
 use namespace::autoclean;
@@ -154,7 +155,7 @@ has pause_cfg_file => (
 =attr pause_cfg_dir
 
 This is the directory for resolving a relative L</pause_cfg_file>.
-It defaults to C<< File::HomeDir->my_home >>.
+it defaults to the glob expansion of F<~>.
 
 =cut
 
@@ -162,7 +163,7 @@ has pause_cfg_dir => (
   is      => 'ro',
   isa     => 'Str',
   lazy    => 1,
-  default => sub { require File::HomeDir; File::HomeDir::->my_home },
+  default => sub { Dist::Zilla::Util->homedir },
 );
 
 =attr pause_cfg

--- a/lib/Dist/Zilla/Util.pm
+++ b/lib/Dist/Zilla/Util.pm
@@ -102,13 +102,16 @@ sub expand_config_package_name {
   shift; goto &_expand_config_package_name
 }
 
+sub homedir {
+  $^O eq 'MSWin32' && "$]" < 5.016 ? $ENV{HOME} || $ENV{USERPROFILE} : (glob('~'))[0];
+}
+
 sub _global_config_root {
   require Dist::Zilla::Path;
   return Dist::Zilla::Path::path($ENV{DZIL_GLOBAL_CONFIG_ROOT}) if $ENV{DZIL_GLOBAL_CONFIG_ROOT};
 
-  require File::HomeDir;
-  my $homedir = File::HomeDir->my_home
-    or Carp::croak("couldn't determine home directory");
+  my $homedir = homedir();
+  Carp::croak("couldn't determine home directory") if not $homedir;
 
   return Dist::Zilla::Path::path($homedir)->child('.dzil');
 }


### PR DESCRIPTION
...as inspired by File::HomeDir::Tiny

Note that all of this can be replaced by (glob('~'))[0] when perl 5.20
is required.

(This is a simplification of a piece of an earlier pull request, and is suitable for merging in the v6 series.)