### PR TITLE
Add a --jobs argument to dzil release #621

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - Respect jobs number in HARNESS_OPTIONS
 
 6.013     2019-04-30 07:35:49-04:00 America/New_York (TRIAL RELEASE)
         - when SPDX metadata is available for the chosen license,

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
         - Respect jobs number in HARNESS_OPTIONS
+        - Add --jobs argument to dzil release
 
 6.013     2019-04-30 07:35:49-04:00 America/New_York (TRIAL RELEASE)
         - when SPDX metadata is available for the chosen license,

--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -22,6 +22,7 @@ sub abstract { 'release your dist' }
 
 sub opt_spec {
   [ 'trial' => 'build a trial release that PAUSE will not index' ],
+  [ 'jobs|j=i' => 'number of parallel test jobs to run' ],
 }
 
 sub execute {
@@ -35,6 +36,7 @@ sub execute {
     $zilla = $self->zilla;
   }
 
+  local $ENV{HARNESS_OPTIONS} = join ':', split(':', $ENV{HARNESS_OPTIONS} // ''), 'j'.$opt->jobs if $opt->jobs;
   $self->zilla->release;
 }
 

--- a/lib/Dist/Zilla/Role/TestRunner.pm
+++ b/lib/Dist/Zilla/Role/TestRunner.pm
@@ -33,7 +33,10 @@ to the C<test> method.
 has default_jobs => (
   is      => 'ro',
   isa     => 'Int', # non-negative
-  default => 1,
+  lazy    => 1,
+  default => sub {
+    return ($ENV{HARNESS_OPTIONS} // '') =~ / \b j(\d+) \b /x ? $1 : 1;
+  },
 );
 
 around dump_config => sub {


### PR DESCRIPTION
This adds a --jobs argument to dzil release. Along the way it also fixes the mindless overriding of HARNESS_OPTIONS.