### PR TITLE
fix missing newline before pod when TRIAL and versionfix

### DIFF
--- a/lib/Dist/Zilla/Plugin/PkgVersion.pm
+++ b/lib/Dist/Zilla/Plugin/PkgVersion.pm
@@ -269,9 +269,16 @@ sub munge_perl {
 
     my $clean_version = $version =~ tr/_//dr;
     $perl .= (
-      $self->use_our
-        ? "\n\$VERSION\x20=\x20'$clean_version';"
-        : "\n\$$package\::VERSION\x20=\x20'$clean_version';"
+        (
+          $self->use_our
+            ? "\n\$VERSION\x20=\x20'$clean_version';"
+            : "\n\$$package\::VERSION\x20=\x20'$clean_version';"
+        ).
+        (
+          $blank
+            ? "\n"
+            : ""
+        )
       ) if $version ne $clean_version;
 
     # Why can't I use PPI::Token::Unknown? -- rjbs, 2014-01-11

--- a/t/plugins/pkgversion.t
+++ b/t/plugins/pkgversion.t
@@ -123,6 +123,13 @@ my $script_pkg = '
 package DZT::Script;
 ';
 
+my $pod_with_pkg_trial = 'package DZT::PodWithPackageTrial;
+
+=pod
+
+=cut
+';
+
 my $pod_with_pkg = '
 package DZT::PodWithPackage;
 =pod
@@ -358,6 +365,35 @@ my $pod_no_pkg = '
     $dzt_sample_trial,
     qr{^\s*\$\QDZT::Sample::VERSION = '0.001'; # TRIAL\E\s*$}m,
     "added version with 'TRIAL' comment when \$ENV{TRIAL}=1",
+  );
+}
+
+{
+  local $ENV{TRIAL} = 1;
+
+  my $tzil_trial = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/lib/DZT/PodWithPackageTrial.pm' => $pod_with_pkg_trial,
+        'source/dist.ini' => simple_ini(
+          { # merge into root section
+            version => '0.004_002',
+          },
+          [ GatherDir => ],
+          [ PkgVersion => ],
+        ),
+      },
+    },
+  );
+
+  $tzil_trial->build;
+
+  my $dzt_podwithpackagetrial = $tzil_trial->slurp_file('build/lib/DZT/PodWithPackageTrial.pm');
+  like(
+    $dzt_podwithpackagetrial,
+    qr{^\s*\$\QDZT::PodWithPackageTrial::VERSION = '0.004_002'; # TRIAL\E\s*.+^=pod}ms,
+    "added version to DZT::PodWithPackageTrial",
   );
 }
 


### PR DESCRIPTION
I had a strange error in a special case. The pod would be not starting in a fresh line!

PkgVersion produce something like this:
`$DZT::PodWithPackageTrial::VERSION = '0.004002';=pod`

It also depends on how many newlines are at the beginning before the package definition. When the package is the first line it breaks, when the package is after a empty line everything works.

Attached a test and the fix for this special case.
