### PR TITLE
Added some basic documentation of the jobs option

### DIFF
--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -11,10 +11,31 @@ use Dist::Zilla::App -command;
 
   dzil release --trial
 
+  # long form, jobs takes an integer
+  dzil release --jobs 9
+
+  # short form, same as above
+  dzil release --jobs 9
+
 This command is a very, very thin wrapper around the
 C<L<release|Dist::Zilla/release>> method on the Dist::Zilla object.  It will
-build, archive, and release your distribution using your Releaser plugins.  The
-only option, C<--trial>, will cause it to build a trial build.
+build, archive, and release your distribution using your Releaser plugins.
+
+Available options are:
+
+=over
+
+=item C<--trial>, will cause it to build a trial build.
+
+=item C<--jobs|-j=i>, number of test jobs run in parallel using L<Test::Harness|Test::Harness>.
+
+=back
+
+The default for L<Test::Harness|Test::Harness> is C<9>. The number of parallel jobs can also be specified setting C<HARNESS_OPTIONS>.
+
+    HARNESS_OPTIONS=j9
+
+See L<Test::Harness|Test::Harness> for more details.
 
 =cut
 

--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -15,7 +15,7 @@ use Dist::Zilla::App -command;
   dzil release --jobs 9
 
   # short form, same as above
-  dzil release --jobs 9
+  dzil release -j 9
 
 This command is a very, very thin wrapper around the
 C<L<release|Dist::Zilla/release>> method on the Dist::Zilla object.  It will


### PR DESCRIPTION
I was updating the Dash cheatsheet and saw that the documentation had not been updated with the `--jobs` option.

So here is a suggestion