### PR TITLE
restore Changes entry for 6.013

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,11 @@ Revision history for {{$dist->name}}
           (thanks Doug Bell)
         - tests for [CPANFile] (thanks, Daniel Böhmer)
 
+6.013     2019-04-30 07:35:49-04:00 America/New_York (TRIAL RELEASE)
+        - when SPDX metadata is available for the chosen license,
+          x_spdx_expression is added to the dist metadata by default
+          (thanks, Leon Timmermans!)
+
 6.012     2018-04-21 10:20:21+02:00 Europe/Oslo
         - revert addition of Archive::Tar::Wrapper as a mandatory prereq (in
           release 6.011).


### PR DESCRIPTION
looks like a bad rebase of aae06736 caused this section to be accidentally lost.