### PR TITLE
Fix loading of `dist.pl` re GH#654

### DIFF
--- a/lib/Dist/Zilla/MVP/Reader/Perl.pm
+++ b/lib/Dist/Zilla/MVP/Reader/Perl.pm
@@ -30,7 +30,7 @@ sub read_into_assembler {
 
   while (my ($ident, $arg) = splice @$plugins, 0, 2) {
     unless (ref $arg) {
-      unshift @$plugins, $arg;
+      unshift @$plugins, $arg if defined $arg;
       $arg = [];
     }
 
@@ -43,9 +43,9 @@ sub read_into_assembler {
   }
 
   # should be done ... elsewhere? -- rjbs, 2009-08-24
-  $self->assembler->end_section if $self->assembler->current_section;
+  $asm->end_section if $asm->current_section;
 
-  return $self->assembler->sequence;
+  return $asm->sequence;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/distpl.t
+++ b/t/distpl.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+
+use Test::DZil;
+
+my $tzil = Builder->from_config(
+  { dist_root => 'corpus/dist/DZ2' },
+);
+
+$tzil->chrome->logger->set_debug(1);
+$tzil->build;
+pass();
+done_testing;


### PR DESCRIPTION
This provides the most minimal changes I think might work.

( Though I suspect more changes are desired/necessary to bring full feature-comparability with the likes of dist.ini and bundles )

Importantly:

- The sub called $self->assembler instead of using the passed $asm,
  indicating that this code probably never worked.

- When a plugin definition is not specified as a ( key => ref ) pair,
  and instead there is only 'key', if the next element doesn't exist,
  the existing code shoves an `undef` back into @plugins when it should
  do nothing, resulting in a complete failure trying to create a section
  with an undef name, entirely breaking things like:

    [ '@Classic' ]

  This code no longer injects a new "undef" that was previously not in
  the input data, into the plugin data.

- A very very rudimentary 'it builds' test is added for DZ2/dist.pl test
  case.

Bug: https://github.com/rjbs/Dist-Zilla/issues/654