### PR TITLE
Fixes issue #656 failed tests in t/plugins/manifest.t

### DIFF
--- a/t/plugins/manifest.t
+++ b/t/plugins/manifest.t
@@ -17,7 +17,7 @@ my $tzil = Builder->from_config(
         'GatherDir',
         'Manifest',
       ),
-      $^O =~ /^(MSWin32|cygwin)$/ ? () : (
+      $^O =~ /^(MSWin32|cygwin|msys)$/ ? () : (
         q{source/file\\with some\\whacks.txt} => "bar\n",
         q{source/file'with'quotes\\or\\backslash.txt} => "quux\n",
         q{source/dir\\with some\\/whacks.txt} => "mar\n",
@@ -39,7 +39,7 @@ cmp_deeply(
     'dist.ini',
     'lib/DZT/Sample.pm',
     't/basic.t',
-    $^O =~ /^(MSWin32|cygwin)$/ ? () : (
+    $^O =~ /^(MSWin32|cygwin|msys)$/ ? () : (
       q{file\\with some\\whacks.txt},
       q{file'with'quotes\\or\\backslash.txt},
       q{dir\\with some\\/whacks.txt},
@@ -60,7 +60,7 @@ cmp_deeply(
     'dist.ini',
     'lib/DZT/Sample.pm',
     't/basic.t',
-    $^O =~ /^(MSWin32|cygwin)$/ ? () : (
+    $^O =~ /^(MSWin32|cygwin|msys)$/ ? () : (
       q{'file\\\\with some\\\\whacks.txt'},
       q{'file\\'with\\'quotes\\\\or\\\\backslash.txt'},
       q{'dir\\\\with some\\\\/whacks.txt'},


### PR DESCRIPTION
Fixes issue #656. Commit 02d2e176e `additional fix for #361 on cygwin` added checks for `MSWin32` and `cygwin` but not for `msys` (MSYS2) to handle the Windows specific  part of the code. This fixes the test failures in #656 for me.