### PR TITLE
Add prerequisite App::cpanminus

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,6 +46,8 @@ Mixin::Linewise::Readers = 0.100    ; default encodings to UTF-8
 
 DateTime = 0.44 ; CLDR fixes, used by AutoVersion and NextRelease
 
+App::cpanminus = 0; Essentail for dzil install  
+
 [OSPrereqs / MSWin32]
 DateTime::TimeZone = 1.92
 

--- a/dist.ini
+++ b/dist.ini
@@ -28,6 +28,10 @@ Archive::Tar::Wrapper = 0.15
 ; https://github.com/rjbs/Data-OptList/pull/1
 Data::OptList = 0.110
 
+; default install util for dzil, otherwise you need to specify
+;     (e.g. "dzil install --install-command cpan")  
+App::cpanminus = 0
+
 [Prereqs / RuntimeSuggests]
 PPI::XS = 0
 
@@ -45,8 +49,6 @@ ExtUtils::Manifest       = 1.54     ; for ManifestSkip that needs maniskip()
 Mixin::Linewise::Readers = 0.100    ; default encodings to UTF-8
 
 DateTime = 0.44 ; CLDR fixes, used by AutoVersion and NextRelease
-
-App::cpanminus = 0; Essentail for dzil install  
 
 [OSPrereqs / MSWin32]
 DateTime::TimeZone = 1.92


### PR DESCRIPTION
After installing Dist::Zilla via `cpan`, I tried running `dzil install` and it failed with the following error:

>    Can't exec "cpanm": No such file or directory 

After installing App::cpanminus, there were no problems, hence the suggested addition of App::cpanminus as a dependency.