### PR TITLE
Fixed broken Chrome link in Dist::Zilla's pod. Resolves rjbs/Dist-Zilla#663.

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -750,7 +750,7 @@ sub _write_out_file {
 =attr logger
 
 This attribute stores a L<Log::Dispatchouli::Proxy> object, used to log
-messages.  By default, a proxy to the dist's L<Chrome|Dist::Zilla::Chrome> is
+messages.  By default, a proxy to the dist's L<Chrome|Dist::Zilla::Role::Chrome> is
 taken.
 
 The following methods are delegated from the Dist::Zilla object to the logger:


### PR DESCRIPTION
The Dist::Zilla pod's ATTRIBUTES / logger section contains a "Chrome" link to Dist::Zilla::Chrome which isn't a module. Changed to Dist::Zilla::Role::Chrome.