### PR TITLE
Require PPI 1.222 for package version accessor

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -45,6 +45,7 @@ Config::MVP::Reader::INI = 2.101461 ; allow spaces in plugin name
 Data::Section            = 0.200000 ; default encodings to UTF-8
 ExtUtils::Manifest       = 1.54     ; for ManifestSkip that needs maniskip()
 Mixin::Linewise::Readers = 0.100    ; default encodings to UTF-8
+PPI::Document            = 1.222    ; version accessor for package stmt
 Term::ANSIColor          = 5.00     ; 24-bit color support
 
 DateTime = 0.44 ; CLDR fixes, used by AutoVersion and NextRelease


### PR DESCRIPTION
This module appears to be added to dependencies through autoprereqs currently, but it is lazyloaded so there's no way to auto-set the required version; so just add it manually.

Resolves #669 