### PR TITLE
Improve error message for failed 'dzil run'

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -20,6 +20,7 @@ use Dist::Zilla::Path; # because more Path::* is better, eh?
 use Try::Tiny;
 use List::Util 1.45 'uniq';
 use Module::Runtime 'require_module';
+use IPC::System::Simple ();
 
 use namespace::autoclean;
 
@@ -841,7 +842,7 @@ sub run_in_build {
     my $wd = File::pushd::pushd($target);
 
     if ($arg and exists $arg->{build} and ! $arg->{build}) {
-      system(@$cmd) and die "error while running: @$cmd";
+      IPC::System::Simple::run(@$cmd);
       return 1;
     }
 
@@ -855,7 +856,7 @@ sub run_in_build {
       (map { $abstarget->child('blib', $_) } qw(bin script)),
       (defined $ENV{PATH} ? $ENV{PATH} : ());
 
-    system(@$cmd) and die "error while running: @$cmd";
+    IPC::System::Simple::run(@$cmd);
     1;
   };
 


### PR DESCRIPTION
This improves the error message provided by 'dzil run' to indicate the resulting exit status of a failed command. An example of where this might help is during exploratory testing using 'dzil run perl'.

In particular I ran into this problem when a module I was doing such testing with crashed with SIGSEGV: with no output from perl itself and only a very basic message from dzil, I had to guess (or discover via strace) what had actually happened.