### PR TITLE
fix "dzil authordeps --missing"

### DIFF
--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -120,7 +120,7 @@ sub extract_author_deps {
         : do {
             my $m = $_;
             ! eval {
-              local @INC = @INC; push @INC, $root;
+              local @INC = @INC; push @INC, "$root";
               # This will die if module is missing
               Module::Runtime::require_module($m);
               my $v = $vermap->{$m};


### PR DESCRIPTION
https://github.com/rjbs/Dist-Zilla/pull/627 added . to INC for "dzil authordeps --missing".

After that, `dzil authordeps --missing` does not work correctly.

This is because `$root` is an object of `Dist::Zilla::Path` so that `Module::Runtime::require_module` sometimes fails with the message:

```
Can't locate object method "INC" via package "Dist::Zilla::Path"
```

This PR fixes it by stringifying `$root` before adding it to INC.