### PR TITLE
suggest cpanm $(dzil) to avoid piping

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -314,7 +314,7 @@ Required plugin$bundle $package isn't installed.
 Run 'dzil authordeps' to see a list of all required plugins.
 You can pipe the list to your CPAN client to install or update them:
 
-    dzil authordeps --missing | cpanm
+    cpanm $(dzil authordeps --missing)
 
 END_DIE
 

--- a/lib/Dist/Zilla/Plugin/MetaTests.pm
+++ b/lib/Dist/Zilla/Plugin/MetaTests.pm
@@ -23,7 +23,7 @@ following files:
   xt/author/meta-yaml.t - a standard Test::CPAN::Meta test
 
 L<Test::CPAN::Meta> will be added as a C<develop requires> dependency (which
-can be installed via C<< dzil listdeps --author | cpanm >>).
+can be installed via C<< cpanm $(dzil listdeps --author) >>).
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Running `dzil ... | cpanm` works but I generally don't recommend it since cpanm loses some functionalities like prompting on failures when STDIN is piped this way.

This PR changes the command outputs to suggest using `cpanm $(dzil ...)` instead.

Note: One subtle difference would be that if the `dzil` commands emit no outputs, the new invocation would give an error message from `cpanm` because no argument would be given to the command. It could be slightly confusing, but I think that's unlikely to happen, since this suggestion is only displayed when there're actually modules missing.