### PR TITLE
mark some subroutine arguments as optional

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -616,7 +616,7 @@ like matching the glob C<Your-Dist-*>.
 
 =cut
 
-sub clean ($self, $dry_run) {
+sub clean ($self, $dry_run = undef) {
   require File::Path;
   for my $x (grep { -e } '.build', glob($self->name . '-*')) {
     if ($dry_run) {

--- a/lib/Dist/Zilla/Util/AuthorDeps.pm
+++ b/lib/Dist/Zilla/Util/AuthorDeps.pm
@@ -9,7 +9,7 @@ use List::Util 1.45 ();
 
 use namespace::autoclean;
 
-sub format_author_deps ($reqs, $versions) {
+sub format_author_deps ($reqs, $versions = undef) {
   my $formatted = '';
   foreach my $rec (@{ $reqs }) {
     my ($mod, $ver) = each(%{ $rec });
@@ -19,7 +19,7 @@ sub format_author_deps ($reqs, $versions) {
   return $formatted;
 }
 
-sub extract_author_deps ($root, $missing) {
+sub extract_author_deps ($root, $missing = undef) {
   my $ini = path($root, 'dist.ini');
 
   die "dzil authordeps only works on dist.ini files, and you don't have one\n"


### PR DESCRIPTION
This fixes "Too few arguments for subroutine ..." errors from downstream plugins, e.g.:
https://www.cpantesters.org/cpan/report/e5a8a17e-dfa6-11ec-842b-e399c271694f
https://www.cpantesters.org/cpan/report/54d1b008-ec69-11ec-96ae-f2ec22c97367
https://www.cpantesters.org/cpan/report/770212ee-ec69-11ec-be85-cbf022c97367