### PR TITLE
allow DZIL_COLOR=0 to turn off colorization regardless of stdout

### DIFF
--- a/lib/Dist/Zilla/Chrome/Term.pm
+++ b/lib/Dist/Zilla/Chrome/Term.pm
@@ -74,7 +74,7 @@ sub _build_logger {
     quiet_fatal => 'stdout',
   });
 
-  if (-t *STDOUT || $ENV{DZIL_COLOR}) {
+  if (defined $ENV{DZIL_COLOR} ? $ENV{DZIL_COLOR} : -t *STDOUT) {
     my $stdout = $logger->{dispatcher}->output('stdout');
 
     $stdout->add_callback(sub {


### PR DESCRIPTION
This partly addresses #671 for me.  It makes DZIL_COLOR=0 override the -t test on STDOUT, so that if I set the variable on Windows I can turn off the color output which doesn't work.  This may also benefit non-windows users that want to turn off color output regardless of if this is a run in a terminal.

Arguably colorization should be turned off on windows regardless since ANSI sequences aren't recognized by the cmd.exe window, but I will leave that for a later PR if there is agreement.