### PR TITLE
dzil add: follow %Mint config if no options given

### DIFF
--- a/lib/Dist/Zilla/App/Command/add.pm
+++ b/lib/Dist/Zilla/App/Command/add.pm
@@ -24,11 +24,9 @@ sub abstract { 'add modules to an existing dist' }
 sub usage_desc { '%c %o <ModuleName>' }
 
 sub opt_spec {
-  [ 'profile|p=s',  'name of the profile to use',
-    { default => 'default' }  ],
+  [ 'profile|p=s',  'name of the profile to use' ],
 
-  [ 'provider|P=s', 'name of the profile provider to use',
-    { default => 'Default' }  ],
+  [ 'provider|P=s', 'name of the profile provider to use' ],
 
   # [ 'module|m=s@', 'module(s) to create; may be given many times'         ],
 }
@@ -51,12 +49,22 @@ sub execute {
 
   my $zilla = $self->zilla;
   my $dist = $zilla->name;
-  
+
   require File::pushd;
+
+  my $mint_stash = $zilla->stash_named('%Mint');
+
+  my $provider = $opt->provider
+    // ($mint_stash && $mint_stash->provider)
+    // 'Default';
+
+  my $profile = $opt->profile
+    // ($mint_stash && $mint_stash->profile)
+    // 'default';
 
   require Dist::Zilla::Dist::Minter;
   my $minter = Dist::Zilla::Dist::Minter->_new_from_profile(
-    [ $opt->provider, $opt->profile ],
+    [ $provider, $profile ],
     {
       chrome  => $self->app->chrome,
       name    => $dist,


### PR DESCRIPTION
If a provider and profile are specified as options, fall back to using options from the %Mint stash before using the defaults. This will use the same config as the new command, but also allows that to be overridden in the dist's own dist.ini file.