### PR TITLE
do not warn about 'uninitialized value' on non-symlink platforms

### DIFF
--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -779,7 +779,7 @@ sub test {
 
   $self->log("all's well; removing $target");
   $target->remove_tree({ safe => 0 });
-  $latest->remove_tree({ safe => 0 }) if -d $latest; # error cannot unlink, is a directory
+  $latest->remove_tree({ safe => 0 }) if $latest && -d $latest; # error cannot unlink, is a directory
   $latest->remove if $latest;
 }
 


### PR DESCRIPTION
'dzil test' warns on some platforms about 'uninitialized value latest'. (see https://github.com/PerlServices/OPM-Maker-Command-depcheck/actions/runs/5146304937/jobs/9265154121#step:7:39)