### PR TITLE
add trial_num attribute to Dist::Zilla and --trial-num option to dzil build and dzil release

### DIFF
--- a/lib/Dist/Zilla.pm
+++ b/lib/Dist/Zilla.pm
@@ -554,6 +554,21 @@ sub _build_is_trial {
     return $self->release_status =~ /\A(?:testing|unstable)\z/ ? 1 : 0;
 }
 
+=attr trial_num
+
+This attribute designates an optional trial number if the dist will be a
+trial release.
+
+=cut
+
+has trial_num => (
+  is => 'rw',
+  isa => 'Maybe[Int]',
+  init_arg => undef,
+  lazy => 1,
+  default => undef,
+);
+
 =attr plugins
 
 This is an arrayref of plugins that have been plugged into this Dist::Zilla

--- a/lib/Dist/Zilla/App/Command/build.pm
+++ b/lib/Dist/Zilla/App/Command/build.pm
@@ -7,7 +7,7 @@ use Dist::Zilla::App -command;
 
 =head1 SYNOPSIS
 
-  dzil build [ --trial ] [ --tgz | --no-tgz ] [ --in /path/to/build/dir ]
+  dzil build [ --trial ] [ --trial-num=# ] [ --tgz | --no-tgz ] [ --in /path/to/build/dir ]
 
 =head1 DESCRIPTION
 
@@ -62,6 +62,7 @@ sub abstract { 'build your dist' }
 
 sub opt_spec {
   [ 'trial'  => 'build a trial release that PAUSE will not index'      ],
+  [ 'trial-num=i' => 'optional trial release number (implies --trial)' ],
   [ 'tgz!'   => 'build a tarball (default behavior)', { default => 1 } ],
   [ 'in=s'   => 'the directory in which to build the distribution'     ]
 }
@@ -72,6 +73,11 @@ sub opt_spec {
 
 This will build a trial distribution.  Among other things, it will generally
 mean that the built tarball's basename ends in F<-TRIAL>.
+
+=head2 --trial-num
+
+Specifies an optional trial release number and implies C<--trial>.  This will
+be appended to the built tarball's trial designation, e.g. F<-TRIAL9>.
 
 =head2 --tgz | --no-tgz
 
@@ -101,9 +107,10 @@ sub execute {
     {
       # isolate changes to RELEASE_STATUS to zilla construction
       local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
-      $ENV{RELEASE_STATUS} = 'testing' if $opt->trial;
+      $ENV{RELEASE_STATUS} = 'testing' if $opt->trial or defined $opt->trial_num;
       $zilla  = $self->zilla;
     }
+    $zilla->trial_num($opt->trial_num) if defined $opt->trial_num;
     $zilla->$method;
   }
 

--- a/lib/Dist/Zilla/App/Command/release.pm
+++ b/lib/Dist/Zilla/App/Command/release.pm
@@ -11,6 +11,8 @@ use Dist::Zilla::App -command;
 
   dzil release --trial
 
+  dzil release --trial-num 3
+
   # long form, jobs takes an integer
   dzil release --jobs 9
 
@@ -26,6 +28,8 @@ Available options are:
 =over
 
 =item C<--trial>, will cause it to build a trial build.
+
+=item C<--trial-num=i>, optional trial release number (implies --trial).
 
 =item C<--jobs|-j=i>, number of test jobs run in parallel using L<Test::Harness|Test::Harness>.
 
@@ -43,6 +47,7 @@ sub abstract { 'release your dist' }
 
 sub opt_spec {
   [ 'trial' => 'build a trial release that PAUSE will not index' ],
+  [ 'trial-num=i' => 'optional trial release number (implies --trial)' ],
   [ 'jobs|j=i' => 'number of parallel test jobs to run' ],
 }
 
@@ -53,10 +58,11 @@ sub execute {
   {
     # isolate changes to RELEASE_STATUS to zilla construction
     local $ENV{RELEASE_STATUS} = $ENV{RELEASE_STATUS};
-    $ENV{RELEASE_STATUS} = 'testing' if $opt->trial;
+    $ENV{RELEASE_STATUS} = 'testing' if $opt->trial or defined $opt->trial_num;
     $zilla = $self->zilla;
   }
 
+  $self->zilla->trial_num($opt->trial_num) if defined $opt->trial_num;
   local $ENV{HARNESS_OPTIONS} = join ':', split(':', $ENV{HARNESS_OPTIONS} // ''), 'j'.$opt->jobs if $opt->jobs;
   $self->zilla->release;
 }

--- a/lib/Dist/Zilla/Dist/Builder.pm
+++ b/lib/Dist/Zilla/Dist/Builder.pm
@@ -454,9 +454,11 @@ This method will return the filename, without the format extension
 
 sub archive_basename {
   my ($self) = @_;
+  my $trial_slug = '-TRIAL';
+  $trial_slug .= $self->trial_num if defined $self->trial_num;
   return join q{},
     $self->dist_basename,
-    ( $self->is_trial && $self->version !~ /_/ ? '-TRIAL' : '' ),
+    ( $self->is_trial && $self->version !~ /_/ ? $trial_slug : '' ),
   ;
 }
 

--- a/lib/Dist/Zilla/Plugin/NextRelease.pm
+++ b/lib/Dist/Zilla/Plugin/NextRelease.pm
@@ -34,10 +34,10 @@ use String::Formatter 0.100680 stringf => {
     E => sub { $_[0]->_user_info('email') },
     U => sub { $_[0]->_user_info('name')  },
     T => sub { $_[0]->zilla->is_trial
-                   ? ($_[1] // '-TRIAL') : '' },
+                   ? ($_[1] // ('-TRIAL' . ($_[0]->zilla->trial_num // '') ) ) : '' },
     V => sub { $_[0]->zilla->version
                 . ($_[0]->zilla->is_trial
-                   ? ($_[1] // '-TRIAL') : '') },
+                   ? ($_[1] // ('-TRIAL' . ($_[0]->zilla->trial_num // '') ) ) : '') },
     P => sub {
       my $releaser = first { $_->can('cpanid') } @{ $_[0]->zilla->plugins_with('-Releaser') };
       $_[0]->log_fatal('releaser doesn\'t provide cpanid, but %P used') unless $releaser;
@@ -231,10 +231,10 @@ The distribution version
 = C<%{-TRIAL}T>
 Expands to -TRIAL (or any other supplied string) if this
 is a trial release, or the empty string if not.  A bare C<%T> means
-C<%{-TRIAL}T>.
+C<%{-TRIAL}T>, with the distribution trial number appended if set.
 
 = C<%{-TRIAL}V>
-Equivalent to C<%v%{-TRIAL}T>, to allow for the application of modifiers such
+Equivalent to C<%v%T>, to allow for the application of modifiers such
 as space padding to the entire version string produced.
 
 = C<%{CLDR format}d>

--- a/t/plugins/archive_builder.t
+++ b/t/plugins/archive_builder.t
@@ -21,14 +21,16 @@ my $tzil = Builder->from_config(
   },
 );
 
+$tzil->trial_num(42);
 my $fooball = $tzil->build_archive;
 
 note "fooball = $fooball";
 note "is_trial = @{[ $tzil->is_trial ]}";
+note "trial_num = @{[ $tzil->trial_num ]}";
 
 my @payload = JSON::MaybeXS->new->decode( $fooball->slurp_raw )->@*;
 
-is $payload[0], 'DZT-Sample-0.001-TRIAL';
+is $payload[0], 'DZT-Sample-0.001-TRIAL42';
 ok -d $payload[1];
 is $payload[2], 'DZT-Sample-0.001';
 

--- a/t/plugins/nextrelease.t
+++ b/t/plugins/nextrelease.t
@@ -233,6 +233,32 @@ END_CHANGES
         'source/Changes' => $changes,
         'source/dist.ini' => simple_ini(
                 'GatherDir',
+                [ NextRelease => { format => "%v%T", } ],
+        ),
+      },
+    },
+  );
+
+  $tzil_trial->trial_num(0);
+  $tzil_trial->build;
+
+  like(
+    $tzil_trial->slurp_file('build/Changes'),
+    qr{0.001-TRIAL0},
+    "adding -TRIAL with trial num works",
+  );
+}
+
+{
+  local $ENV{TRIAL} = 1;
+
+  my $tzil_trial = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/Changes' => $changes,
+        'source/dist.ini' => simple_ini(
+                'GatherDir',
                 [ NextRelease => { format => "%-12V ohhai", } ],
         ),
       },
@@ -245,6 +271,32 @@ END_CHANGES
     $tzil_trial->slurp_file('build/Changes'),
     qr{0.001-TRIAL  ohhai},
     "adding -TRIAL with padding works",
+  );
+}
+
+{
+  local $ENV{TRIAL} = 1;
+
+  my $tzil_trial = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/Changes' => $changes,
+        'source/dist.ini' => simple_ini(
+                'GatherDir',
+                [ NextRelease => { format => "%-14V ohhai", } ],
+        ),
+      },
+    },
+  );
+
+  $tzil_trial->trial_num(6);
+  $tzil_trial->build;
+
+  like(
+    $tzil_trial->slurp_file('build/Changes'),
+    qr{0.001-TRIAL6   ohhai},
+    "adding -TRIAL with trial num works",
   );
 }
 

--- a/t/plugins/release_status.t
+++ b/t/plugins/release_status.t
@@ -169,4 +169,46 @@ subtest "from version (testing)" => sub {
   unlike($tzil->archive_filename, qr/-TRIAL/, "no -TRIAL in archive filename");
 };
 
+subtest "trial number set (stable)" => sub {
+  local $ENV{RELEASE_STATUS} = 'stable';
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          'GatherDir',
+        ),
+      },
+    },
+  );
+
+  $tzil->trial_num(1);
+  $tzil->build;
+
+  is($tzil->release_status, 'stable', "release status set from environment");
+  ok(! $tzil->is_trial, "is_trial is not true");
+  unlike($tzil->archive_filename, qr/-TRIAL/, "-TRIAL not in archive filename");
+};
+
+subtest "trial number set (testing)" => sub {
+  local $ENV{RELEASE_STATUS} = 'testing';
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/dist.ini' => simple_ini(
+          'GatherDir',
+        ),
+      },
+    },
+  );
+
+  $tzil->trial_num(1);
+  $tzil->build;
+
+  is($tzil->release_status, 'testing', "release status set from environment");
+  ok($tzil->is_trial, "is_trial is true");
+  like($tzil->archive_filename, qr/-TRIAL1/, "-TRIAL1 in archive filename");
+};
+
 done_testing;


### PR DESCRIPTION
Adds support for creating trial archives with the format `-TRIAL#` via a --trial-num option. Not sure if this is the best way, but this is handled directly by Dist::Zilla::Dist::Builder so it can't be supported via plugins.

Ensures that the number is appended even if it's 0 (as -TRIAL0 is valid) and that nothing is appended unless it's determined to be a trial release via the current mechanisms.

Also updated NextRelease %T and %V default specifications to include the trial num if specified, since this will likely be meant to emulate the archive name.