### PR TITLE
Prune more cruft

### DIFF
--- a/lib/Dist/Zilla/Plugin/PruneCruft.pm
+++ b/lib/Dist/Zilla/Plugin/PruneCruft.pm
@@ -71,6 +71,7 @@ sub exclude_file {
   return 1 if $file->name =~ /\A_Inline/;
   return 1 if $file->name eq 'MYMETA.yml';
   return 1 if $file->name eq 'MYMETA.json';
+  return 1 if substr($file->name, -12) eq 'perltidy.ERR';
   return 1 if $file->name eq 'pm_to_blib';
   return 1 if substr($file->name, 0, 6) eq '_eumm/';
   # Avoid bundling fatlib/ dir created by App::FatPacker

--- a/lib/Dist/Zilla/Plugin/PruneCruft.pm
+++ b/lib/Dist/Zilla/Plugin/PruneCruft.pm
@@ -73,6 +73,7 @@ sub exclude_file {
   return 1 if $file->name eq 'MYMETA.json';
   return 1 if substr($file->name, -12) eq 'perltidy.ERR';
   return 1 if $file->name eq 'pm_to_blib';
+  return 1 if substr($file->name, -1) eq '~';
   return 1 if substr($file->name, 0, 6) eq '_eumm/';
   # Avoid bundling fatlib/ dir created by App::FatPacker
   # https://github.com/andk/pause/pull/65

--- a/t/plugins/prunes.t
+++ b/t/plugins/prunes.t
@@ -120,6 +120,7 @@ for my $skip_skip (0..1) {
   );
 }
 
+
 {
   my $tzil = Builder->from_config(
     { dist_root => 'corpus/dist/DZT' },
@@ -142,6 +143,56 @@ for my $skip_skip (0..1) {
     [ @files ],
     [ qw(dist.ini lib/DZT/Sample.pm t/basic.t Build) ],
     "...but /Build isn't  pruned by PruneCruft if we exclude it",
+  );
+}
+
+{
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/Build'    => "This file is cruft.\n",
+        'source/dist.ini' => simple_ini('GatherDir', 'PruneCruft'),
+        'source/dist.ini~'    => "This backup is cruft.\n",
+        'source/dist.ini~1~'  => "This backup is cruft.\n",
+        'source/%dist.ini%~'  => "This backup is cruft.\n",
+      },
+    },
+  );
+
+  $tzil->build;
+
+  my @files = map {; $_->name } @{ $tzil->files };
+
+  is_filelist(
+    [ @files ],
+    [ qw(dist.ini lib/DZT/Sample.pm t/basic.t) ],
+    "/dist.ini~ is pruned by PruneCruft",
+  );
+}
+
+{
+  my $tzil = Builder->from_config(
+    { dist_root => 'corpus/dist/DZT' },
+    {
+      add_files => {
+        'source/Build'    => "This file is cruft.\n",
+        'source/dist.ini' => simple_ini('GatherDir', 'PruneCruft'),
+        'source/perltidy.ERR' => "This file is cruft.\n",
+        'source/t/perltidy.ERR' => "This file is cruft.\n",
+        'source/lib/DZT/perltidy.ERR' => "This file is cruft.\n",
+      },
+    },
+  );
+
+  $tzil->build;
+
+  my @files = map {; $_->name } @{ $tzil->files };
+
+  is_filelist(
+    [ @files ],
+    [ qw(dist.ini lib/DZT/Sample.pm t/basic.t) ],
+    "perltidy.ERR files are pruned by PruneCruft",
   );
 }
 
@@ -244,4 +295,3 @@ for my $arg (qw(filename filenames)) {
 }
 
 done_testing;
-


### PR DESCRIPTION
This modifies the PruneCruft plugin to prune other kinds of files that are commonly left in a directory:
- Backup files ending with "~" that are created by Emacs and other tools
- Perl::Tidy error logs