### PR TITLE
FAILING: Have DZ generate Makefile.PL with INSTALLDIRS

### DIFF
--- a/lib/Dist/Zilla/Plugin/MakeMaker.pm
+++ b/lib/Dist/Zilla/Plugin/MakeMaker.pm
@@ -260,6 +260,7 @@ sub write_makefile_args {
     VERSION   => $self->zilla->version,
     LICENSE   => $self->zilla->license->meta_yml_name,
     @exe_files ? ( EXE_FILES => [ sort @exe_files ] ) : (),
+    INSTALLDIRS => ($] < 5.011 ? 'perl' : 'site'),
 
     CONFIGURE_REQUIRES => $require_prereqs{configure},
     keys %{ $require_prereqs{build} } ? ( BUILD_REQUIRES => $require_prereqs{build} ) : (),

--- a/t/plugins/makemaker.t
+++ b/t/plugins/makemaker.t
@@ -40,6 +40,7 @@ use Test::DZil;
     LICENSE  => 'perl',
     MIN_PERL_VERSION => '5.010',
     test => { TESTS => 't/*.t' },
+    INSTALLDIRS => ($] < 5.011 ? 'perl' : 'site'),
 
     PREREQ_PM          => {
       'Foo::Bar' => '1.20',
@@ -58,8 +59,12 @@ use Test::DZil;
     test => { TESTS => 't/*.t' },
   );
 
+  my $hashref = $makemaker->__write_makefile_args;
+#  print STDERR Dumper($hashref); # $hashref lacks INSTALLDIRS kvp
+#  print STDERR Dumper(\%want); # %want is okay; has INSTALLDIRS kvp
   cmp_deeply(
-    $makemaker->__write_makefile_args,
+      #$makemaker->__write_makefile_args,
+    $hashref,
     \%want,
     'correct makemaker args generated',
   );


### PR DESCRIPTION
**This pull request is submitted solely as a demonstration of a problem.  It is currently failing one test and is not mergeable.  Feedback requested.**

There exist several CPAN distributions which (a) are "dual-life" distributions shipped with the Perl 5 core underneath 'cpan/'; (b) in core, do not have their own Makefile.PL files; (c) have been determined to lack INSTALLDIRS key-value pairs in their upstream Makefile.PL files; and (d) lack an INSTALLDIRS kvp there because the Makefile.PL has been generated by Dist::Zilla::Plugin::Makemaker (or something that inherits therefrom).

Attempting to alleviate this problem going forwards, I herein tried to create a pull request in which I first added a test for the presence of INSTALLDIRS in a DZ-generated Makefile.PL (which at first failed, as expected), and then added code in Dist::Zilla::Plugin::Makemaker to insert such an INSTALLDIRS kvp.  However, I cannot get t/plugins/makemaker.t to PASS.  It repeatedly fails the first unit test therein.  I do not understand DZ enough to fix this failure.  See approx. line 62 of t/plugins/makemaker.t.